### PR TITLE
Enforce Immutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0
+
+Enforce Immutability ([#25](https://github.com/felangel/equatable/issues/25))
+
 # 0.2.6
 
 Improved support for collection types ([#19](https://github.com/felangel/equatable/issues/19))

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   equatable:

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -1,14 +1,17 @@
+import 'package:meta/meta.dart';
 import './equatable_utils.dart';
 
-/// A class that helps implement equality
-/// without needing to explicitly override == and [hashCode].
-/// Equatables override their own == and [hashCode] based on
-/// the provided `properties`.
+@immutable
 abstract class Equatable {
   /// The [List] of `props` (properties) which will be used to determine whether
   /// two [Equatables] are equal.
   final List props;
 
+  /// A class that helps implement equality
+  /// without needing to explicitly override == and [hashCode].
+  /// Equatables override their own == and [hashCode] based on
+  /// the provided `properties`.
+  ///
   /// The constructor takes an optional [List] of `props` (properties) which
   /// will be used to determine whether two [Equatables] are equal.
   /// If no properties are provided, `props` will be initialized to
@@ -24,7 +27,4 @@ abstract class Equatable {
 
   @override
   int get hashCode => runtimeType.hashCode ^ mapPropsToHashCode(props);
-
-  @override
-  String toString() => props.isNotEmpty ? props.toString() : super.toString();
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -1,3 +1,4 @@
+import 'package:meta/meta.dart';
 import './equatable_utils.dart';
 
 /// You must define the [EquatableMixinBase] on the class
@@ -5,11 +6,9 @@ import './equatable_utils.dart';
 /// `class EquatableDateTime extends DateTime with EquatableMixinBase, EquatableMixin { ... }`
 /// This exposes the `props` getter which can then be overridden to include custom props in subclasses.
 /// The `props` getter is used to override `==` and `hashCode` in the [EquatableMixin].
+@immutable
 mixin EquatableMixinBase on Object {
   List get props => [];
-
-  @override
-  String toString() => super.toString();
 }
 
 /// You must define the [EquatableMixin] on the class
@@ -27,7 +26,4 @@ mixin EquatableMixin on EquatableMixinBase {
 
   @override
   int get hashCode => runtimeType.hashCode ^ mapPropsToHashCode(props);
-
-  @override
-  String toString() => props.isNotEmpty ? props.toString() : super.toString();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: An abstract class that helps to implement equality without needing to explicitly override == and hashCode.
-version: 0.2.6
+version: 0.3.0
 author: Felix Angelov <felangelov@gmail.com>
 homepage: https://github.com/felangel/equatable
 
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.14.11
+  meta: ^1.1.6
 
 dev_dependencies:
   test: ">=1.3.0 <2.0.0"

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -119,7 +119,7 @@ void main() {
   group('Simple Equatable (string)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), '[simple]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<String>'");
     });
 
     test('should return true when instance is the same', () {
@@ -164,7 +164,7 @@ void main() {
   group('Simple Equatable (number)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(0);
-      expect(instance.toString(), '[0]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<int>'");
     });
 
     test('should return true when instance is the same', () {
@@ -203,7 +203,7 @@ void main() {
   group('Simple Equatable (bool)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(true);
-      expect(instance.toString(), '[true]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<bool>'");
     });
 
     test('should return true when instance is the same', () {
@@ -245,7 +245,8 @@ void main() {
         key: 'foo',
         value: 'bar',
       ));
-      expect(instance.toString(), '[[foo, bar]]');
+      expect(
+          instance.toString(), "Instance of 'SimpleEquatable<EquatableData>'");
     });
     test('should return true when instance is the same', () {
       final instance = SimpleEquatable(EquatableData(
@@ -304,7 +305,7 @@ void main() {
   group('Multipart Equatable', () {
     test('should correct toString', () {
       final instance = MultipartEquatable("s1", "s2");
-      expect(instance.toString(), '[s1, s2]');
+      expect(instance.toString(), "Instance of 'MultipartEquatable<String>'");
     });
     test('should return true when instance is the same', () {
       final instance = MultipartEquatable("s1", "s2");
@@ -353,7 +354,7 @@ void main() {
         hairColor: Color.black,
         children: ['Bob'],
       );
-      expect(instance.toString(), '[Joe, 40, Color.black, [Bob]]');
+      expect(instance.toString(), "Instance of 'ComplexEquatable'");
     });
     test('should return true when instance is the same', () {
       final instance = ComplexEquatable(
@@ -437,7 +438,7 @@ void main() {
         }
         """,
       ) as Map<String, dynamic>);
-      expect(instance.toString(), '[Admin, admin]');
+      expect(instance.toString(), "Instance of 'Credentials'");
     });
 
     test('should return true when instance is the same', () {

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -103,7 +103,7 @@ void main() {
   group('Simple Equatable (string)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), '[simple]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<String>'");
     });
 
     test('should return true when instance is the same', () {
@@ -148,7 +148,7 @@ void main() {
   group('Simple Equatable (number)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(0);
-      expect(instance.toString(), '[0]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<int>'");
     });
 
     test('should return true when instance is the same', () {
@@ -187,7 +187,7 @@ void main() {
   group('Simple Equatable (bool)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(true);
-      expect(instance.toString(), '[true]');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<bool>'");
     });
 
     test('should return true when instance is the same', () {
@@ -229,7 +229,8 @@ void main() {
         key: 'foo',
         value: 'bar',
       ));
-      expect(instance.toString(), '[[foo, bar]]');
+      expect(
+          instance.toString(), "Instance of 'SimpleEquatable<EquatableData>'");
     });
     test('should return true when instance is the same', () {
       final instance = SimpleEquatable(EquatableData(
@@ -288,7 +289,7 @@ void main() {
   group('Multipart Equatable', () {
     test('should correct toString', () {
       final instance = MultipartEquatable("s1", "s2");
-      expect(instance.toString(), '[s1, s2]');
+      expect(instance.toString(), "Instance of 'MultipartEquatable<String>'");
     });
     test('should return true when instance is the same', () {
       final instance = MultipartEquatable("s1", "s2");
@@ -337,7 +338,7 @@ void main() {
         hairColor: Color.black,
         children: ['Bob'],
       );
-      expect(instance.toString(), '[Joe, 40, Color.black, [Bob]]');
+      expect(instance.toString(), "Instance of 'ComplexEquatable'");
     });
     test('should return true when instance is the same', () {
       final instance = ComplexEquatable(
@@ -421,7 +422,7 @@ void main() {
         }
         """,
       ) as Map<String, dynamic>);
-      expect(instance.toString(), '[Admin, admin]');
+      expect(instance.toString(), "Instance of 'Credentials'");
     });
 
     test('should return true when instance is the same', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
Addresses #25
- `Equatable` and `EquatableMixinBase` enforce immutability.
- Remove `toString` overrides

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
None