### PR TITLE
remove EquatableMixinBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0
+
+- Removed `EquatableMixinBase`, now covered by `EquatableMixin`.
+- Typed `EquatableMixin` from `List<dynamic>` to `List<Object>`, to fix linter
+  issues with `implicit-dynamic: false`.
+
 # 0.4.0
 
 Update `toString` to default to `runtimeType` ([#27](https://github.com/felangel/equatable/issues/27))

--- a/README.md
+++ b/README.md
@@ -186,11 +186,10 @@ In this case, you can still get the benefits of `Equatable` by using the `Equata
 
 ### Usage
 
-Let's say we want to make an `EquatableDateTime` class, we can use `EquatableMixinBase` and `EquatableMixin` like so:
+Let's say we want to make an `EquatableDateTime` class, we can use `EquatableMixin` like so:
 
 ```dart
-class EquatableDateTime extends DateTime
-    with EquatableMixinBase, EquatableMixin {
+class EquatableDateTime extends DateTime with EquatableMixin {
   EquatableDateTime(
     int year, [
     int month = 1,
@@ -203,16 +202,16 @@ class EquatableDateTime extends DateTime
   ]) : super(year, month, day, hour, minute, second, millisecond, microsecond);
 
   @override
-  List get props {
+  List<Object> get props {
     return [year, month, day, hour, minute, second, millisecond, microsecond];
   }
 }
 ```
 
-Now if we want to create a subclass of `EquatableDateTime`, we can continue to just use the `EquatableMixin` and override `props`.
+Now if we want to create a subclass of `EquatableDateTime`, we can just override `props`.
 
 ```dart
-class EquatableDateTimeSubclass extends EquatableDateTime with EquatableMixin {
+class EquatableDateTimeSubclass extends EquatableDateTime {
   final int century;
 
   EquatableDateTime(
@@ -228,7 +227,7 @@ class EquatableDateTimeSubclass extends EquatableDateTime with EquatableMixin {
   ]) : super(year, month, day, hour, minute, second, millisecond, microsecond);
 
   @override
-  List get props => super.props..addAll([century]);
+  List<Object> get props => super.props..addAll([century]);
 }
 ```
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -7,8 +7,7 @@ class Credentials extends Equatable {
   Credentials({this.username, this.password}) : super([username, password]);
 }
 
-class EquatableDateTime extends DateTime
-    with EquatableMixinBase, EquatableMixin {
+class EquatableDateTime extends DateTime with EquatableMixin {
   EquatableDateTime(
     int year, [
     int month = 1,

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -1,21 +1,12 @@
-import 'package:meta/meta.dart';
 import './equatable_utils.dart';
 
-/// You must define the [EquatableMixinBase] on the class
-/// which you want to make Equatable.
-/// `class EquatableDateTime extends DateTime with EquatableMixinBase, EquatableMixin { ... }`
-/// This exposes the `props` getter which can then be overridden to include custom props in subclasses.
-/// The `props` getter is used to override `==` and `hashCode` in the [EquatableMixin].
-@immutable
-mixin EquatableMixinBase on Object {
-  List get props => [];
-}
-
 /// You must define the [EquatableMixin] on the class
-/// which you want to make Equatable and the class
-/// must also be a descendent of [EquatableMixinBase].
+/// which you want to make Equatable.
+///
 /// [EquatableMixin] does the override of the `==` operator as well as `hashCode`.
-mixin EquatableMixin on EquatableMixinBase {
+mixin EquatableMixin {
+  List<Object> get props;
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: An abstract class that helps to implement equality without needing to explicitly override == and hashCode.
-version: 0.4.0
+version: 0.5.0
 author: Felix Angelov <felangelov@gmail.com>
 homepage: https://github.com/felangel/equatable
 

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -5,41 +5,44 @@ import 'package:equatable/equatable.dart';
 
 class NonEquatable {}
 
-class EquatableBase with EquatableMixinBase, EquatableMixin {}
+abstract class EquatableBase with EquatableMixin {}
 
-class EmptyEquatable extends EquatableBase with EquatableMixin {}
+class EmptyEquatable extends EquatableBase {
+  @override
+  List<Object> get props => const [];
+}
 
-class SimpleEquatable<T> extends EquatableBase with EquatableMixin {
+class SimpleEquatable<T> extends EquatableBase {
   final T data;
 
   SimpleEquatable(this.data);
 
   @override
-  List get props => super.props..addAll([data]);
+  List get props => [data];
 }
 
-class MultipartEquatable<T> extends EquatableBase with EquatableMixin {
+class MultipartEquatable<T> extends EquatableBase {
   final T d1;
   final T d2;
 
   MultipartEquatable(this.d1, this.d2);
 
   @override
-  List get props => super.props..addAll([d1, d2]);
+  List get props => [d1, d2];
 }
 
-class OtherEquatable extends EquatableBase with EquatableMixin {
+class OtherEquatable extends EquatableBase {
   final String data;
 
   OtherEquatable(this.data);
 
   @override
-  List get props => super.props..addAll([data]);
+  List get props => [data];
 }
 
 enum Color { blonde, black, brown }
 
-class ComplexEquatable extends EquatableBase with EquatableMixin {
+class ComplexEquatable extends EquatableBase {
   final String name;
   final int age;
   final Color hairColor;
@@ -48,27 +51,27 @@ class ComplexEquatable extends EquatableBase with EquatableMixin {
   ComplexEquatable({this.name, this.age, this.hairColor, this.children});
 
   @override
-  List get props => super.props..addAll([name, age, hairColor, children]);
+  List get props => [name, age, hairColor, children];
 }
 
-class EquatableData extends EquatableBase with EquatableMixin {
+class EquatableData extends EquatableBase {
   final String key;
   final dynamic value;
 
   EquatableData({this.key, this.value});
 
   @override
-  List get props => super.props..addAll([key, value]);
+  List get props => [key, value];
 }
 
-class Credentials extends EquatableBase with EquatableMixin {
+class Credentials extends EquatableBase {
   final String username;
   final String password;
 
   Credentials({this.username, this.password});
 
   @override
-  List get props => super.props..addAll([username, password]);
+  List get props => [username, password];
 
   factory Credentials.fromJson(Map<String, dynamic> json) {
     return Credentials(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description

It removes `EquatableMixinBase` by making it built-in `EquatableMixin` 

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```dart
class Foo with EquatableMixinBase, EquatableMixin {
  Foo(this.a);
  final int a;

  @override
  List<Object> get props => [a];
}
```

now becomes:

```dart
class Foo with EquatableMixin {
  Foo(this.a);
  final int a;

  @override
  List<Object> get props => [a];
}
```
