### PR TITLE
aligning readme with package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ First, we need to do add `equatable` to the dependencies of the `pubspec.yaml`
 
 ```yaml
 dependencies:
-  equatable: ^0.6.0
+  equatable: ^0.6.1
 ```
 
 Next, we need to install it:


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
It seems the correct version is 0.6.1 and not 0.6.0 since many will probably copy and paste from the documentation, it makes sense to make it align with the correct number. Perhaps you may need to even release one more time with the correct version. 

## Impact to Remaining Code Base
This PR will affect nothing expect it will correct documentation

Thanks for your great work!