### PR TITLE
Implement toString feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,39 @@ class Person extends Equatable {
 }
 ```
 
+### `toString` Implementation
+Equatable can implement `toString` method including all the given props. If you want that behaviour, just include the following:
+```
+  @override
+  bool get stringable => true;
+```
+
+For instance:
+
+```dart
+import 'package:equatable/equatable.dart';
+
+class Person extends Equatable {
+  final String name;
+
+  const Person(this.name);
+
+  @override
+  List<Object> get props => [name];
+  
+  @override
+  bool get stringable => true;
+}
+```
+For the name `Bob`, the outuput will be:
+```
+Person(Bob)
+```
+This flag by default is false and `toString` will return just the type:
+```
+Person
+```
+
 ## Recap
 
 ### Without Equatable

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ class Person extends Equatable {
 Equatable can implement `toString` method including all the given props. If you want that behaviour, just include the following:
 ```
   @override
-  bool get stringable => true;
+  bool get stringify => true;
 ```
 
 For instance:
@@ -187,7 +187,7 @@ class Person extends Equatable {
   List<Object> get props => [name];
   
   @override
-  bool get stringable => true;
+  bool get stringify => true;
 }
 ```
 For the name `Bob`, the outuput will be:

--- a/example/main.dart
+++ b/example/main.dart
@@ -8,6 +8,9 @@ class Credentials extends Equatable {
 
   @override
   List<Object> get props => [username, password];
+
+  @override
+  bool get stringable => false;
 }
 
 class EquatableDateTime extends DateTime with EquatableMixin {
@@ -26,6 +29,9 @@ class EquatableDateTime extends DateTime with EquatableMixin {
   List get props {
     return [year, month, day, hour, minute, second, millisecond, microsecond];
   }
+
+  @override
+  bool get stringable => true;
 }
 
 void main() {
@@ -39,6 +45,7 @@ void main() {
   print(credentialsC == credentialsC); // true
   print(credentialsA == credentialsB); // false
   print(credentialsB == credentialsC); // true
+  print(credentialsA.toString()); // Credentials
 
   // Equatable Mixin
   final dateTimeA = EquatableDateTime(2019);
@@ -50,4 +57,5 @@ void main() {
   print(dateTimeC == dateTimeC); // true
   print(dateTimeA == dateTimeB); // false
   print(dateTimeB == dateTimeC); // true
+  print(dateTimeA.toString()); // EquatableDateTime(2019, 1, 1, 0, 0, 0, 0, 0)
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -10,7 +10,7 @@ class Credentials extends Equatable {
   List<Object> get props => [username, password];
 
   @override
-  bool get stringable => false;
+  bool get stringify => false;
 }
 
 class EquatableDateTime extends DateTime with EquatableMixin {
@@ -31,7 +31,7 @@ class EquatableDateTime extends DateTime with EquatableMixin {
   }
 
   @override
-  bool get stringable => true;
+  bool get stringify => true;
 }
 
 void main() {

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -20,7 +20,9 @@ abstract class Equatable {
   /// two [Equatables] are equal.
   List<Object> get props;
 
-  bool get stringable => false;
+  /// If the value is [true], the `toString` method will be overrided to print
+  /// the equatable `props`.
+  bool get stringify => false;
 
   /// A class that helps implement equality
   /// without needing to explicitly override == and [hashCode].
@@ -39,5 +41,5 @@ abstract class Equatable {
 
   @override
   String toString() =>
-      stringable ? toStringWithProps(runtimeType, props) : '$runtimeType';
+      stringify ? mapPropsToString(runtimeType, props) : '$runtimeType';
 }

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+
 import './equatable_utils.dart';
 
 /// A base class to facilitate [operator==] and [hashCode] overrides.
@@ -19,6 +20,8 @@ abstract class Equatable {
   /// two [Equatables] are equal.
   List<Object> get props;
 
+  bool get stringable => false;
+
   /// A class that helps implement equality
   /// without needing to explicitly override == and [hashCode].
   /// Equatables override their own `==` operator and [hashCode] based on their `props`.
@@ -35,5 +38,6 @@ abstract class Equatable {
   int get hashCode => runtimeType.hashCode ^ mapPropsToHashCode(props);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() =>
+      stringable ? toStringWithProps(runtimeType, props) : '$runtimeType';
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -9,7 +9,9 @@ mixin EquatableMixin {
   /// two [Equatables] are equal.
   List<Object> get props;
 
-  bool get stringable => false;
+  /// If the value is [true], the `toString` method will be overrided to print
+  /// the equatable `props`.
+  bool get stringify => false;
 
   @override
   bool operator ==(Object other) {
@@ -24,5 +26,5 @@ mixin EquatableMixin {
 
   @override
   String toString() =>
-      stringable ? toStringWithProps(runtimeType, props) : '$runtimeType';
+      stringify ? mapPropsToString(runtimeType, props) : '$runtimeType';
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -9,6 +9,8 @@ mixin EquatableMixin {
   /// two [Equatables] are equal.
   List<Object> get props;
 
+  bool get stringable => false;
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -21,5 +23,6 @@ mixin EquatableMixin {
   int get hashCode => runtimeType.hashCode ^ mapPropsToHashCode(props);
 
   @override
-  String toString() => '$runtimeType';
+  String toString() =>
+      stringable ? toStringWithProps(runtimeType, props) : '$runtimeType';
 }

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 
 int mapPropsToHashCode(Iterable props) =>
-    _finish(props.fold(0, (hash, object) => _combine(hash, object)));
+    _finish(props?.fold(0, (hash, object) => _combine(hash, object)) ?? 0);
 
 const DeepCollectionEquality _equality = DeepCollectionEquality();
 

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -46,3 +46,6 @@ int _finish(int hash) {
   hash = hash ^ (hash >> 11);
   return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
 }
+
+String toStringWithProps(Type runtimeType, List<Object> props) =>
+    '$runtimeType${props.map((prop) => prop != null ? prop.toString() : '')}';

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -48,5 +48,5 @@ int _finish(int hash) {
   return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
 }
 
-String toStringWithProps(Type runtimeType, List<Object> props) =>
+String mapPropsToString(Type runtimeType, List<Object> props) =>
     '$runtimeType${props.map((prop) => prop != null ? prop.toString() : '')}';

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -49,4 +49,4 @@ int _finish(int hash) {
 }
 
 String mapPropsToString(Type runtimeType, List<Object> props) =>
-    '$runtimeType${props.map((prop) => prop != null ? prop.toString() : '')}';
+    '$runtimeType${props?.map((prop) => prop?.toString() ?? '') ?? '()'}';

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -89,17 +89,28 @@ class Credentials extends EquatableBase {
   }
 }
 
-class ComplexStringable extends ComplexEquatable {
+class ComplexStringify extends ComplexEquatable {
   final String name;
   final int age;
   final Color hairColor;
 
-  ComplexStringable({this.name, this.age, this.hairColor});
+  ComplexStringify({this.name, this.age, this.hairColor});
 
   @override
   List get props => [name, age, hairColor];
+
   @override
-  bool get stringable => true;
+  bool get stringify => true;
+}
+
+class NullProps extends Equatable {
+  NullProps();
+
+  @override
+  List get props => null;
+
+  @override
+  bool get stringify => true;
 }
 
 void main() {
@@ -559,15 +570,35 @@ void main() {
       expect(instanceA == instanceB, false);
     });
   });
+
   group('To String Equatable', () {
-    test('Complex stringable', () {
-      final instanceA = ComplexStringable();
-      final instanceB = ComplexStringable(name: "Bob", hairColor: Color.black);
+    test('Complex stringify', () {
+      final instanceA = ComplexStringify();
+      final instanceB = ComplexStringify(name: "Bob", hairColor: Color.black);
       final instanceC =
-          ComplexStringable(name: "Joe", age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ComplexStringable(, , )');
-      expect(instanceB.toString(), 'ComplexStringable(Bob, , Color.black)');
-      expect(instanceC.toString(), 'ComplexStringable(Joe, 50, Color.blonde)');
+          ComplexStringify(name: "Joe", age: 50, hairColor: Color.blonde);
+      expect(instanceA.toString(), 'ComplexStringify(, , )');
+      expect(instanceB.toString(), 'ComplexStringify(Bob, , Color.black)');
+      expect(instanceC.toString(), 'ComplexStringify(Joe, 50, Color.blonde)');
+    });
+  });
+
+  group('Null props Equatable', () {
+    test('should not crash invoking equals method', () {
+      final instanceA = NullProps();
+      final instanceB = NullProps();
+      expect(instanceA == instanceB, true);
+    });
+
+    test('should not crash invoking hascode method', () {
+      final instanceA = NullProps();
+      final instanceB = NullProps();
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should not crash invoking toString method', () {
+      final instance = NullProps();
+      expect(instance.toString(), 'NullProps()');
     });
   });
 }

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 
+import 'package:equatable/equatable.dart';
 import 'package:equatable/src/equatable_utils.dart';
 import 'package:test/test.dart';
-import 'package:equatable/equatable.dart';
 
 class NonEquatable {}
 
@@ -87,6 +87,19 @@ class Credentials extends EquatableBase {
     data['password'] = this.password;
     return data;
   }
+}
+
+class ComplexStringable extends ComplexEquatable {
+  final String name;
+  final int age;
+  final Color hairColor;
+
+  ComplexStringable({this.name, this.age, this.hairColor});
+
+  @override
+  List get props => [name, age, hairColor];
+  @override
+  bool get stringable => true;
 }
 
 void main() {
@@ -528,6 +541,17 @@ void main() {
         """,
       ) as Map<String, dynamic>);
       expect(instanceA == instanceB, false);
+    });
+  });
+  group('To String Equatable', () {
+    test('Complex stringable', () {
+      final instanceA = ComplexStringable();
+      final instanceB = ComplexStringable(name: "Bob", hairColor: Color.black);
+      final instanceC =
+          ComplexStringable(name: "Joe", age: 50, hairColor: Color.blonde);
+      expect(instanceA.toString(), 'ComplexStringable(, , )');
+      expect(instanceB.toString(), 'ComplexStringable(Bob, , Color.black)');
+      expect(instanceC.toString(), 'ComplexStringable(Joe, 50, Color.blonde)');
     });
   });
 }

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -1,9 +1,8 @@
 import 'dart:convert';
 
+import 'package:equatable/equatable.dart';
 import 'package:equatable/src/equatable_utils.dart';
 import 'package:test/test.dart';
-
-import 'package:equatable/equatable.dart';
 
 import 'custom_list.dart';
 
@@ -90,6 +89,19 @@ class Credentials extends Equatable {
 
   @override
   List<Object> get props => [username, password];
+}
+
+class ComplexStringable extends Equatable {
+  final String name;
+  final int age;
+  final Color hairColor;
+
+  ComplexStringable({this.name, this.age, this.hairColor});
+
+  @override
+  List get props => [name, age, hairColor];
+  @override
+  bool get stringable => true;
 }
 
 void main() {
@@ -719,6 +731,17 @@ void main() {
         expect(instanceA != instanceB, true);
         expect(instanceA.hashCode != instanceB.hashCode, true);
       });
+    });
+  });
+  group('To String Equatable', () {
+    test('Complex stringable', () {
+      final instanceA = ComplexStringable();
+      final instanceB = ComplexStringable(name: "Bob", hairColor: Color.black);
+      final instanceC =
+          ComplexStringable(name: "Joe", age: 50, hairColor: Color.blonde);
+      expect(instanceA.toString(), 'ComplexStringable(, , )');
+      expect(instanceB.toString(), 'ComplexStringable(Bob, , Color.black)');
+      expect(instanceC.toString(), 'ComplexStringable(Joe, 50, Color.blonde)');
     });
   });
 }

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -91,17 +91,28 @@ class Credentials extends Equatable {
   List<Object> get props => [username, password];
 }
 
-class ComplexStringable extends Equatable {
+class ComplexStringify extends Equatable {
   final String name;
   final int age;
   final Color hairColor;
 
-  ComplexStringable({this.name, this.age, this.hairColor});
+  ComplexStringify({this.name, this.age, this.hairColor});
 
   @override
   List get props => [name, age, hairColor];
+
   @override
-  bool get stringable => true;
+  bool get stringify => true;
+}
+
+class NullProps extends Equatable {
+  NullProps();
+
+  @override
+  List get props => null;
+
+  @override
+  bool get stringify => true;
 }
 
 void main() {
@@ -733,15 +744,35 @@ void main() {
       });
     });
   });
+
   group('To String Equatable', () {
-    test('Complex stringable', () {
-      final instanceA = ComplexStringable();
-      final instanceB = ComplexStringable(name: "Bob", hairColor: Color.black);
+    test('with Complex stringify', () {
+      final instanceA = ComplexStringify();
+      final instanceB = ComplexStringify(name: "Bob", hairColor: Color.black);
       final instanceC =
-          ComplexStringable(name: "Joe", age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ComplexStringable(, , )');
-      expect(instanceB.toString(), 'ComplexStringable(Bob, , Color.black)');
-      expect(instanceC.toString(), 'ComplexStringable(Joe, 50, Color.blonde)');
+          ComplexStringify(name: "Joe", age: 50, hairColor: Color.blonde);
+      expect(instanceA.toString(), 'ComplexStringify(, , )');
+      expect(instanceB.toString(), 'ComplexStringify(Bob, , Color.black)');
+      expect(instanceC.toString(), 'ComplexStringify(Joe, 50, Color.blonde)');
+    });
+  });
+
+  group('Null props Equatable', () {
+    test('should not crash invoking equals method', () {
+      final instanceA = NullProps();
+      final instanceB = NullProps();
+      expect(instanceA == instanceB, true);
+    });
+
+    test('should not crash invoking hascode method', () {
+      final instanceA = NullProps();
+      final instanceB = NullProps();
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should not crash invoking toString method', () {
+      final instance = NullProps();
+      expect(instance.toString(), 'NullProps()');
     });
   });
 }


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
I implemented the `toString` method feature using the props. 

I think it is a very useful feature for testing and debugging that most of developers that use this library would like to use.  It could be able to do this through an own subclass of equatable or another library but I think that it is overkill for this small feature. This library override already that method and there is no impact implementing this.

## Related PRs
No related PRs.

## Todos
There is no TODOs
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
This new feature will not have impact in the code base, functionality or performance.
It is disabled by default and does not force the user to do changes.