### PR TITLE
Increase minor version to release hashCode fix and toString feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.4
+
+- Fix `hashCode` error when `props` is null
+- Added `stringify` feature (optional `toString` override)
+
 # 1.0.3
 
 - Fix `hashCode` collisions for lists within props ([#53](https://github.com/felangel/equatable/pull/53))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.4
+# 1.1.0
 
 - Fix `hashCode` error when `props` is null
 - Added `stringify` feature (optional `toString` override)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: An abstract class that helps to implement equality without needing to explicitly override == and hashCode.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/felangel/equatable
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: An abstract class that helps to implement equality without needing to explicitly override == and hashCode.
-version: 1.0.4
+version: 1.1.0
 homepage: https://github.com/felangel/equatable
 
 environment:


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
I was not sure if I had to increase the version and update the change log in my previous PR: https://github.com/felangel/equatable/pull/45/

Since we fixed the `hashCode` error when props is null, I think it could be interesting release those changes soon. 

