### PR TITLE
Default props to empty list

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -18,7 +18,7 @@ import './equatable_utils.dart';
 abstract class Equatable {
   /// The [List] of `props` (properties) which will be used to determine whether
   /// two [Equatables] are equal.
-  List<Object> get props;
+  List<Object> get props => const [];
 
   /// If the value is [true], the `toString` method will be overrided to print
   /// the equatable `props`.

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -8,7 +8,7 @@ import './equatable_utils.dart';
 mixin EquatableMixin {
   /// The [List] of `props` (properties) which will be used to determine whether
   /// two [Equatables] are equal.
-  List<Object> get props;
+  List<Object> get props => const [];
 
   /// If the value is [true], the `toString` method will be overrided to print
   /// the equatable `props`.


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Defaulting `props` to an empty list takes away some boilerplate.
Both `null` and `const []` were options, but I'm not sure if either of those has advantages over the other.
