### PR TITLE
Iterable hashCode fix

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -45,27 +45,29 @@ class T<E> extends Equatable{
 }
 
 void main() {
-  // Extending Equatable
-  final credentialsA = Credentials(username: 'Joe', password: 'password123');
-  final credentialsB = Credentials(username: 'Bob', password: 'password!');
-  final credentialsC = Credentials(username: 'Bob', password: 'password!');
-
-  print(credentialsA == credentialsA); // true
-  print(credentialsB == credentialsB); // true
-  print(credentialsC == credentialsC); // true
-  print(credentialsA == credentialsB); // false
-  print(credentialsB == credentialsC); // true
-  print(credentialsA.toString()); // Credentials
-
-  // Equatable Mixin
-  final dateTimeA = EquatableDateTime(2019);
-  final dateTimeB = EquatableDateTime(2019, 2, 20, 19, 46);
-  final dateTimeC = EquatableDateTime(2019, 2, 20, 19, 46);
-
-  print(dateTimeA == dateTimeA); // true
-  print(dateTimeB == dateTimeB); // true
-  print(dateTimeC == dateTimeC); // true
-  print(dateTimeA == dateTimeB); // false
-  print(dateTimeB == dateTimeC); // true
-  print(dateTimeA.toString()); // EquatableDateTime(2019, 1, 1, 0, 0, 0, 0, 0)
+  print(T([0]).hashCode);
+  print(T([0,0,0]).hashCode);
+//  // Extending Equatable
+//  final credentialsA = Credentials(username: 'Joe', password: 'password123');
+//  final credentialsB = Credentials(username: 'Bob', password: 'password!');
+//  final credentialsC = Credentials(username: 'Bob', password: 'password!');
+//
+//  print(credentialsA == credentialsA); // true
+//  print(credentialsB == credentialsB); // true
+//  print(credentialsC == credentialsC); // true
+//  print(credentialsA == credentialsB); // false
+//  print(credentialsB == credentialsC); // true
+//  print(credentialsA.toString()); // Credentials
+//
+//  // Equatable Mixin
+//  final dateTimeA = EquatableDateTime(2019);
+//  final dateTimeB = EquatableDateTime(2019, 2, 20, 19, 46);
+//  final dateTimeC = EquatableDateTime(2019, 2, 20, 19, 46);
+//
+//  print(dateTimeA == dateTimeA); // true
+//  print(dateTimeB == dateTimeB); // true
+//  print(dateTimeC == dateTimeC); // true
+//  print(dateTimeA == dateTimeB); // false
+//  print(dateTimeB == dateTimeC); // true
+//  print(dateTimeA.toString()); // EquatableDateTime(2019, 1, 1, 0, 0, 0, 0, 0)
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:collection/collection.dart';
 
 class Credentials extends Equatable {
   final String username;
@@ -32,6 +33,15 @@ class EquatableDateTime extends DateTime with EquatableMixin {
 
   @override
   bool get stringify => true;
+}
+
+class T<E> extends Equatable{
+  final E value;
+
+  T(this.value);
+
+  @override
+  List<Object> get props => [value];
 }
 
 void main() {

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:collection/collection.dart';
 
 class Credentials extends Equatable {
   final String username;

--- a/example/main.dart
+++ b/example/main.dart
@@ -35,39 +35,28 @@ class EquatableDateTime extends DateTime with EquatableMixin {
   bool get stringify => true;
 }
 
-class T<E> extends Equatable{
-  final E value;
-
-  T(this.value);
-
-  @override
-  List<Object> get props => [value];
-}
-
 void main() {
-  print(T([0]).hashCode);
-  print(T([0,0,0]).hashCode);
-//  // Extending Equatable
-//  final credentialsA = Credentials(username: 'Joe', password: 'password123');
-//  final credentialsB = Credentials(username: 'Bob', password: 'password!');
-//  final credentialsC = Credentials(username: 'Bob', password: 'password!');
-//
-//  print(credentialsA == credentialsA); // true
-//  print(credentialsB == credentialsB); // true
-//  print(credentialsC == credentialsC); // true
-//  print(credentialsA == credentialsB); // false
-//  print(credentialsB == credentialsC); // true
-//  print(credentialsA.toString()); // Credentials
-//
-//  // Equatable Mixin
-//  final dateTimeA = EquatableDateTime(2019);
-//  final dateTimeB = EquatableDateTime(2019, 2, 20, 19, 46);
-//  final dateTimeC = EquatableDateTime(2019, 2, 20, 19, 46);
-//
-//  print(dateTimeA == dateTimeA); // true
-//  print(dateTimeB == dateTimeB); // true
-//  print(dateTimeC == dateTimeC); // true
-//  print(dateTimeA == dateTimeB); // false
-//  print(dateTimeB == dateTimeC); // true
-//  print(dateTimeA.toString()); // EquatableDateTime(2019, 1, 1, 0, 0, 0, 0, 0)
+  // Extending Equatable
+  final credentialsA = Credentials(username: 'Joe', password: 'password123');
+  final credentialsB = Credentials(username: 'Bob', password: 'password!');
+  final credentialsC = Credentials(username: 'Bob', password: 'password!');
+
+  print(credentialsA == credentialsA); // true
+  print(credentialsB == credentialsB); // true
+  print(credentialsC == credentialsC); // true
+  print(credentialsA == credentialsB); // false
+  print(credentialsB == credentialsC); // true
+  print(credentialsA.toString()); // Credentials
+
+  // Equatable Mixin
+  final dateTimeA = EquatableDateTime(2019);
+  final dateTimeB = EquatableDateTime(2019, 2, 20, 19, 46);
+  final dateTimeC = EquatableDateTime(2019, 2, 20, 19, 46);
+
+  print(dateTimeA == dateTimeA); // true
+  print(dateTimeB == dateTimeB); // true
+  print(dateTimeC == dateTimeC); // true
+  print(dateTimeA == dateTimeB); // false
+  print(dateTimeB == dateTimeC); // true
+  print(dateTimeA.toString()); // EquatableDateTime(2019, 1, 1, 0, 0, 0, 0, 0)
 }

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -38,7 +38,7 @@ int _combine(int hash, dynamic object) {
     return hash;
   }
   if (object is Iterable) {
-    for(final value in object){
+    for (final value in object) {
       hash = hash ^ _combine(hash, value);
     }
     return hash ^ object.length;

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -1,8 +1,7 @@
 import 'package:collection/collection.dart';
 
 /// Returns a `hashCode` for [props].
-int mapPropsToHashCode(Iterable props) =>
-    _finish(props?.fold(0, _combine) ?? 0);
+int mapPropsToHashCode(Iterable props) => _finish(props?.fold(0, _combine) ?? 0);
 
 const DeepCollectionEquality _equality = DeepCollectionEquality();
 
@@ -37,8 +36,15 @@ int _combine(int hash, dynamic object) {
     });
     return hash;
   }
-  final objectHashCode =
-      object is Iterable ? mapPropsToHashCode(object) : object.hashCode;
+
+  var objectHashCode = 0;
+  if (object is Iterable) {
+    Function deepEq = const DeepCollectionEquality().equals;
+    objectHashCode = deepEq(object).hashCode;
+  } else {
+    objectHashCode = object.hashCode;
+  }
+
   hash = 0x1fffffff & (hash + objectHashCode);
   hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
   return hash ^ (hash >> 6);

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -1,7 +1,8 @@
 import 'package:collection/collection.dart';
 
 /// Returns a `hashCode` for [props].
-int mapPropsToHashCode(Iterable props) => _finish(props?.fold(0, _combine) ?? 0);
+int mapPropsToHashCode(Iterable props) =>
+    _finish(props?.fold(0, _combine) ?? 0);
 
 const DeepCollectionEquality _equality = DeepCollectionEquality();
 
@@ -36,16 +37,14 @@ int _combine(int hash, dynamic object) {
     });
     return hash;
   }
-
-  var objectHashCode = 0;
   if (object is Iterable) {
-    Function deepEq = const DeepCollectionEquality().equals;
-    objectHashCode = deepEq(object).hashCode;
-  } else {
-    objectHashCode = object.hashCode;
+    object.forEach((value) {
+      hash = hash ^ _combine(hash, value);
+    });
+    return hash + object.length;
   }
 
-  hash = 0x1fffffff & (hash + objectHashCode);
+  hash = 0x1fffffff & (hash + object.hashCode);
   hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
   return hash ^ (hash >> 6);
 }

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -38,9 +38,9 @@ int _combine(int hash, dynamic object) {
     return hash;
   }
   if (object is Iterable) {
-    object.forEach((value) {
+    for(final value in object){
       hash = hash ^ _combine(hash, value);
-    });
+    }
     return hash ^ object.length;
   }
 

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -41,7 +41,7 @@ int _combine(int hash, dynamic object) {
     object.forEach((value) {
       hash = hash ^ _combine(hash, value);
     });
-    return hash + object.length;
+    return hash ^ object.length;
   }
 
   hash = 0x1fffffff & (hash + object.hashCode);

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -131,6 +131,7 @@ class NullProps extends Equatable {
 
 void main() {
   EquatableConfig.stringify = false;
+
   group('Empty Equatable', () {
     test('should correct toString', () {
       final instance = EmptyEquatable();
@@ -611,6 +612,13 @@ void main() {
 
   group('Collection Equatable', () {
     group('Iterable Equatable', () {
+
+      test('list of zeros same hashcode check', () {
+        final s0 = SimpleEquatable([0,0]);
+        final s1 = SimpleEquatable([0,0,0]);
+        expect(s0.hashCode != s1.hashCode, true);
+      });
+
       test('should return when values are same', () {
         final instanceA = SimpleEquatable<Iterable>(["A", "B"]);
         final instanceB = SimpleEquatable<Iterable>(["A", "B"]);

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -612,10 +612,9 @@ void main() {
 
   group('Collection Equatable', () {
     group('Iterable Equatable', () {
-
       test('list of zeros same hashcode check', () {
-        final s0 = SimpleEquatable([0,0]);
-        final s1 = SimpleEquatable([0,0,0]);
+        final s0 = SimpleEquatable([0, 0]);
+        final s1 = SimpleEquatable([0, 0, 0]);
         expect(s0.hashCode != s1.hashCode, true);
       });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Before fixing, SingleEquatable with a list of zeros returns the same hashcode not depends on how much zeros in it. (closes #74)

## Todos
- [+] Tests
- [ ] Documentation
- [+] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
Please, look at this issue: https://github.com/felangel/equatable/issues/74
```
```
