### PR TITLE
docs: improve and fix public docs

### DIFF
--- a/lib/equatable.dart
+++ b/lib/equatable.dart
@@ -1,3 +1,5 @@
+/// A mixin that helps implement equality without needing to explicitly override
+/// `==` operators or `hashCode`s.
 library equatable;
 
 export './src/equatable.dart';

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -3,7 +3,7 @@ import 'package:meta/meta.dart';
 import './equatable_config.dart';
 import './equatable_utils.dart';
 
-/// A base class to facilitate [operator==] and [hashCode] overrides.
+/// A base class to facilitate [operator ==] and [hashCode] overrides.
 ///
 /// ```dart
 /// class ConstTest extends Equatable {
@@ -17,19 +17,31 @@ import './equatable_utils.dart';
 /// ```
 @immutable
 abstract class Equatable {
-  /// The [List] of `props` (properties) which will be used to determine whether
-  /// two [Equatables] are equal.
+  /// {@template equatable_props}
+  /// The list of properies that will be used to determine whether
+  /// two [Equatable]s are equal.
+  /// {@endtemplate}
   List<Object> get props;
 
-  /// If the value is [true], the `toString` method will be overrided to print
-  /// the equatable `props`.
+  /// {@template equatable_stringify}
+  /// If set to `true`, the [toString] method will be overridden to output
+  /// this [Equatable]'s [props].
+  ///
+  /// A global default value for [stringify] can be set using
+  /// [EquatableConfig.stringify].
+  ///
+  /// If this [Equatable]'s [stringify] is set to null, the value of
+  /// [EquatableConfig.stringify] will be used instead. That value deafults to
+  /// `false`.
+  /// {@endtemplate}
   // ignore: avoid_returning_null
   bool get stringify => null;
 
   /// A class that helps implement equality
-  /// without needing to explicitly override == and [hashCode].
-  /// Equatables override their own `==` operator and [hashCode] based on their
-  /// `props`.
+  /// without needing to explicitly override [operator ==] and [hashCode].
+  ///
+  /// [Equatable]s override their own [operator ==] and [hashCode] based on
+  /// their [props].
   const Equatable();
 
   @override

--- a/lib/src/equatable_config.dart
+++ b/lib/src/equatable_config.dart
@@ -1,10 +1,21 @@
-// ignore: avoid_classes_with_only_static_members
-/// Global [Equatable] configuration settings
+import 'equatable.dart';
+
+// ignore_for_file: avoid_classes_with_only_static_members
+
+/// The default configurion for all [Equatable]s.
+///
+/// Currently, this config class only supports setting a default value for
+/// [stringify].
+///
+/// See also:
+/// * [Equatable.stringify]
 class EquatableConfig {
   /// Global [stringify] setting for all [Equatable] instances.
+  ///
   /// If [stringify] is overridden for a particular [Equatable] instance,
   /// then the local [stringify] value takes precedence
-  /// over `EquatableConfig.stringify`.
+  /// over [EquatableConfig.stringify].
+  ///
   /// This value defaults to false.
   static bool stringify = false;
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -1,18 +1,16 @@
 import 'equatable_config.dart';
 import 'equatable_utils.dart';
 
-/// You must define the [EquatableMixin] on the class
-/// which you want to make Equatable.
+/// A mixin that helps implement equality
+/// without needing to explicitly override [operator ==] and [hashCode].
 ///
-/// [EquatableMixin] does the override of the `==` operator as well as
-/// `hashCode`.
+/// Like with extending [Equatable], the [EquatableMixin] overrides the
+/// [operator ==] as well as the [hashCode] based on the provided [props].
 mixin EquatableMixin {
-  /// The [List] of `props` (properties) which will be used to determine whether
-  /// two [Equatables] are equal.
+  /// {@macro equatable_props}
   List<Object> get props;
 
-  /// If the value is [true], the `toString` method will be overrided to print
-  /// the equatable `props`.
+  /// {@macro equatable_stringify}
   bool get stringify => false;
 
   @override


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

### Problem
When projects that use this library have strict rules around documentation verification (for example, when checking docs in CI), this library makes that CI pipeline fail in some cases. When generating documentation for this library, some warnings arise such as invalid references to symbols (`[Equatables]` doesn't exist, but `[Equatable]` does). This might prevent the aforementioned libraries from getting their docs generated once uploaded to [pub.dev](https://pub.dev/).

An example of this behavior can be found on [the score page of my package KanaKit](https://pub.dev/packages/kana_kit/score).

10 points are deducted from the score, no docs are generated and the following warnings are given:
```
  warning: unresolved doc reference [Equatables]
    from kana_kit.KanaKitConfig.props: (file:///tmp/pub-dartlang-dartdocHOHOHD/pkg/lib/src/models/kana_kit_config.dart:88:20)
    in documentation inherited from equatable.Equatable.props: (file:///tmp/pub-cache-dirFCNUXL/hosted/pub.dartlang.org/equatable-1.2.2/lib/src/equatable.dart:22:20)
  warning: unresolved doc reference [Equatables]
    from kana_kit.Romanization.props: (file:///tmp/pub-dartlang-dartdocHOHOHD/pkg/lib/src/models/romanization/romanization.dart:39:20)
    in documentation inherited from equatable.Equatable.props: (file:///tmp/pub-cache-dirFCNUXL/hosted/pub.dartlang.org/equatable-1.2.2/lib/src/equatable.dart:22:20)
found 2 warnings and 0 errors
```

### Solution
This PR contains fixes for those references, along with some clarification and streamlining for different parts of the API.

Feel free to pick and choose which changes you'd like to keep.
Needless to say, I recommend pulling in the entire PR. 😉 

### Changes
- Clarified and streamlined all public-facing API documentation
- Fixed invalid references to internal and external classes, fields and functions

## Todos
- [x] Tests (N/A)
- [x] Documentation
- [x] Examples (N/A)

## Impact to Remaining Code Base
This PR will affect:

* All public-facing documentation.
