### PR TITLE
docs: fix dartdoc warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.5
+
+- docs: dartdoc improvements ([#80](https://github.com/felangel/equatable/issues/80))
+- docs: minor inline documentation improvements
+
 # 1.2.4
 
 - fix: `EquatableMixin` stringify respects `EquatableConfig.stringify` ([#81](https://github.com/felangel/equatable/issues/81))

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -24,19 +24,19 @@ abstract class Equatable {
 
   /// {@template equatable_props}
   /// The list of properies that will be used to determine whether
-  /// two [Equatable]s are equal.
+  /// two instances are equal.
   /// {@endtemplate}
   List<Object> get props;
 
   /// {@template equatable_stringify}
   /// If set to `true`, the [toString] method will be overridden to output
-  /// this [Equatable]'s [props].
+  /// this instance's [props].
   ///
   /// A global default value for [stringify] can be set using
-  /// [EquatableConfig.stringify].
+  /// `EquatableConfig.stringify`.
   ///
-  /// If this [Equatable]'s [stringify] is set to null, the value of
-  /// [EquatableConfig.stringify] will be used instead. That value deafults to
+  /// If this instance's [stringify] is set to null, the value of
+  /// `EquatableConfig.stringify` will be used instead. This defaults to
   /// `false`.
   /// {@endtemplate}
   // ignore: avoid_returning_null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: An abstract class that helps to implement equality without needing to explicitly override == and hashCode.
-version: 1.2.4
+version: 1.2.5
 repository: https://github.com/felangel/equatable
 issue_tracker: https://github.com/felangel/equatable/issues
 homepage: https://github.com/felangel/equatable


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- docs: fix dartdoc warnings (closes #80)

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples

## Impact to Remaining Code Base
- released as v1.2.5