### PR TITLE
fix typo in equatable documentation

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -23,7 +23,7 @@ abstract class Equatable {
   const Equatable();
 
   /// {@template equatable_props}
-  /// The list of properies that will be used to determine whether
+  /// The list of properties that will be used to determine whether
   /// two instances are equal.
   /// {@endtemplate}
   List<Object> get props;


### PR DESCRIPTION
Replace "properies" to "properties"

## Status
**READY**

## Breaking Changes
NO

## Description
Just fixing a typo

## Related PRs
.

branch | PR
------ | ------
.


## Todos
.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
.

## Impact to Remaining Code Base
This PR will affect:

* None
