### PR TITLE
fix: Stringify null properties as "null" instead of ""

### DIFF
--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -57,4 +57,4 @@ int _finish(int hash) {
 
 /// Returns a string for [props].
 String mapPropsToString(Type runtimeType, List<Object> props) =>
-    '$runtimeType${props?.map((prop) => prop?.toString() ?? '') ?? '()'}';
+    '$runtimeType${props?.map((prop) => prop.toString()) ?? '()'}';

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -594,9 +594,11 @@ void main() {
       final instanceB = ComplexStringify(name: 'Bob', hairColor: Color.black);
       final instanceC =
           ComplexStringify(name: 'Joe', age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ComplexStringify(, , , )');
-      expect(instanceB.toString(), 'ComplexStringify(Bob, , Color.black, )');
-      expect(instanceC.toString(), 'ComplexStringify(Joe, 50, Color.blonde, )');
+      expect(instanceA.toString(), 'ComplexStringify(null, null, null, null)');
+      expect(instanceB.toString(),
+          'ComplexStringify(Bob, null, Color.black, null)');
+      expect(instanceC.toString(),
+          'ComplexStringify(Joe, 50, Color.blonde, null)');
     });
 
     test('with ExplicitStringifyFalse stringify', () {

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -594,11 +594,18 @@ void main() {
       final instanceB = ComplexStringify(name: 'Bob', hairColor: Color.black);
       final instanceC =
           ComplexStringify(name: 'Joe', age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ComplexStringify(null, null, null, null)');
-      expect(instanceB.toString(),
-          'ComplexStringify(Bob, null, Color.black, null)');
-      expect(instanceC.toString(),
-          'ComplexStringify(Joe, 50, Color.blonde, null)');
+      expect(
+        instanceA.toString(),
+        'ComplexStringify(null, null, null, null)',
+      );
+      expect(
+        instanceB.toString(),
+        'ComplexStringify(Bob, null, Color.black, null)',
+      );
+      expect(
+        instanceC.toString(),
+        'ComplexStringify(Joe, 50, Color.blonde, null)',
+      );
     });
 
     test('with ExplicitStringifyFalse stringify', () {

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -811,8 +811,8 @@ void main() {
       final instanceB = ComplexStringify(name: 'Bob', hairColor: Color.black);
       final instanceC =
           ComplexStringify(name: 'Joe', age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ComplexStringify(, , )');
-      expect(instanceB.toString(), 'ComplexStringify(Bob, , Color.black)');
+      expect(instanceA.toString(), 'ComplexStringify(null, null, null)');
+      expect(instanceB.toString(), 'ComplexStringify(Bob, null, Color.black)');
       expect(instanceC.toString(), 'ComplexStringify(Joe, 50, Color.blonde)');
     });
 


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

When an object only has one property and that property is null, this object will be stringified just like it has no properties, which is confusing. This pr fixes this.
Null properties will be stringified as "null" instead of ""

## Related PRs
List related PRs against other branches:
None


## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
import 'package:equatable/equatable.dart';

class Test extends Equatable {
  final String id;

  Test(this.id);

  @override
  bool get stringify => true;

  @override
  List<Object> get props => [id];
}

void main() {
  final test = Test(null);
  print(test.toString());
  // Test(null)
  // was: Test()
}
```

## Impact to Remaining Code Base
This PR will affect:

* toString method of all Equatable subclasses
