### PR TITLE
fix: stringify instance with long properties

### DIFF
--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -57,4 +57,4 @@ int _finish(int hash) {
 
 /// Returns a string for [props].
 String mapPropsToString(Type runtimeType, List<Object> props) =>
-    '$runtimeType${props?.map((prop) => prop.toString()) ?? '()'}';
+    '$runtimeType(${props?.map((prop) => prop.toString())?.join(', ') ?? ""})';

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -835,17 +835,18 @@ void main() {
 
     test('with SuperLongProperties stringify', () {
       final instance = SuperLongPropertiesStringify(
-        "aaaaaaaaaaaaaaa",
-        "aaaaaaaaaaaaaaa",
-        "aaaaaaaaaaaaaaa",
-        "aaaaaaaaaaaaaaa",
-        "aaaaaaaaaaaaaaa",
-        "aaaaaaaaaaaaaaa",
+        'aaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaaaa',
+        'aaaaaaaaaaaaaaa',
       );
       expect(
         instance.toString(),
-        'SuperLongPropertiesStringify(aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, '
-        'aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa)',
+        'SuperLongPropertiesStringify(aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, '
+        'aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, '
+        'aaaaaaaaaaaaaaa)',
       );
     });
 

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -108,6 +108,23 @@ class ComplexStringify extends Equatable {
   bool get stringify => true;
 }
 
+class SuperLongPropertiesStringify extends Equatable {
+  SuperLongPropertiesStringify(this.a, this.b, this.c, this.d, this.e, this.f);
+
+  final String a;
+  final String b;
+  final String c;
+  final String d;
+  final String e;
+  final String f;
+
+  @override
+  List<Object> get props => [a, b, c, d, e, f];
+
+  @override
+  bool get stringify => true;
+}
+
 class ExplicitStringifyFalse extends Equatable {
   ExplicitStringifyFalse({this.name, this.age, this.hairColor});
 
@@ -814,6 +831,22 @@ void main() {
       expect(instanceA.toString(), 'ComplexStringify(null, null, null)');
       expect(instanceB.toString(), 'ComplexStringify(Bob, null, Color.black)');
       expect(instanceC.toString(), 'ComplexStringify(Joe, 50, Color.blonde)');
+    });
+
+    test('with SuperLongProperties stringify', () {
+      final instance = SuperLongPropertiesStringify(
+        "aaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaa",
+      );
+      expect(
+        instance.toString(),
+        'SuperLongPropertiesStringify(aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, '
+        'aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa, aaaaaaaaaaaaaaa)',
+      );
     });
 
     test('with ExplicitStringifyFalse stringify', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
When calling `toString` on a long `Iterable`, dart will omit some of the elements (this is a feature), see [Iterable#toString](https://api.dart.dev/stable/2.10.4/dart-core/Iterable/toString.html).
This causes, when stringify an equatable with very long properties, some of the properties got omitted.
This pr fixes it.

## Related Issues

#94

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
null_safety | #98


## Todos
- [x] Tests

## Steps to Test or Reproduce

See the test `with SuperLongProperties stringify`, the old code will not pass this test.

## Impact to Remaining Code Base
This PR will affect:

* `toString` method of Equatable subclasses with long enough properties and `stringify = true`
