### PR TITLE
fix: support legacy equality overrides

### DIFF
--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -16,7 +16,7 @@ mixin EquatableMixin {
   bool? get stringify => null;
 
   @override
-  bool operator ==(Object other) {
+  bool operator ==(Object? other) {
     return identical(this, other) ||
         other is EquatableMixin &&
             runtimeType == other.runtimeType &&

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -122,6 +122,32 @@ class IterableWithFlag<T> extends Iterable<T> with EquatableMixin {
   Iterator<T> get iterator => list.iterator;
 }
 
+class LegacyEqualityOverride {
+  const LegacyEqualityOverride(this.x);
+
+  final int x;
+
+  @override
+  bool operator ==(dynamic o) {
+    if (identical(this, o)) return true;
+
+    return o is LegacyEqualityOverride && o.x == x;
+  }
+
+  @override
+  int get hashCode => x.hashCode;
+}
+
+class LegacyEqualityOverrideEquatable extends LegacyEqualityOverride
+    with EquatableMixin {
+  LegacyEqualityOverrideEquatable(int x, this.y) : super(x);
+
+  final int y;
+
+  @override
+  List<Object?> get props => [x, y];
+}
+
 void main() {
   setUp(() {
     EquatableConfig.stringify = false;
@@ -660,6 +686,23 @@ void main() {
       final instanceB = SimpleEquatable(
         IterableWithFlag(flag: false, list: [1, 2]),
       );
+
+      expect(instanceA == instanceB, isFalse);
+    });
+  });
+
+  group('LegacyEqualityOverride', () {
+    test('should be equal when different instances have same values', () {
+      final instanceA = LegacyEqualityOverrideEquatable(0, 1);
+      final instanceB = LegacyEqualityOverrideEquatable(0, 1);
+
+      expect(instanceA == instanceB, isTrue);
+    });
+
+    test('should not be equal when different instances have different values',
+        () {
+      final instanceA = LegacyEqualityOverrideEquatable(0, 0);
+      final instanceB = LegacyEqualityOverrideEquatable(0, 1);
 
       expect(instanceA == instanceB, isFalse);
     });


### PR DESCRIPTION
## Status
**HOLD**

## Breaking Changes
NO

## Description
- Support using `EquatableMixin` with Objects that override `==` using `dynamic` (#107)

```dart
class LegacyEqualityOverride {
  const LegacyEqualityOverride(this.x);

  final int x;

  @override
  bool operator ==(dynamic o) {
    if (identical(this, o)) return true;

    return o is LegacyEqualityOverride && o.x == x;
  }

  @override
  int get hashCode => x.hashCode;
}
```

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples