### PR TITLE
feat!: stringify defaults to true in debug mode

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0-nullsafety.4
+
+- feat: `EquatableConfig.stringify` defaults to `true` in debug mode.
+
 # 2.0.0-nullsafety.3
 
 - chore: update dependencies

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ First, we need to do add `equatable` to the dependencies of the `pubspec.yaml`
 
 ```yaml
 dependencies:
-  equatable: ^2.0.0-nullsafety.3
+  equatable: ^2.0.0-nullsafety.4
 ```
 
 Next, we need to install it:
@@ -175,7 +175,7 @@ class Person extends Equatable {
 
 ### `toString` Implementation
 
-Equatable can implement `toString` method including all the given props. If you want that behaviour, just include the following:
+Equatable can implement `toString` method including all the given props. If you want that behaviour for a specific `Equatable` object, just include the following:
 
 ```dart
 @override
@@ -219,6 +219,8 @@ EquatableConfig.stringify = true;
 If `stringify` is overridden for a specific `Equatable` class, then the value of `EquatableConfig.stringify` is ignored.
 In other words, the local configuration always takes precedence over the global configuration.
 
+_Note: `EquatableConfig.stringify` defaults to `true` in debug mode and `false` in release mode._
+
 ## Recap
 
 ### Without Equatable
@@ -250,7 +252,7 @@ class Person extends Equatable {
   const Person(this.name);
 
   final String name;
-  
+
   @override
   List<Object> get props => [name];
 }

--- a/lib/src/equatable_config.dart
+++ b/lib/src/equatable_config.dart
@@ -15,6 +15,18 @@ class EquatableConfig {
   /// then the local [stringify] value takes precedence
   /// over [EquatableConfig.stringify].
   ///
-  /// This value defaults to false.
-  static bool stringify = false;
+  /// This value defaults to true in debug mode and false in release mode.
+  static bool get stringify {
+    if (_stringify == null) {
+      assert(() {
+        _stringify = true;
+        return true;
+      }());
+    }
+    return _stringify ??= false;
+  }
+
+  static set stringify(bool value) => _stringify = value;
+
+  static bool? _stringify;
 }

--- a/lib/src/equatable_config.dart
+++ b/lib/src/equatable_config.dart
@@ -9,6 +9,7 @@ import 'equatable.dart';
 /// See also:
 /// * [Equatable.stringify]
 class EquatableConfig {
+  /// {@template stringify}
   /// Global [stringify] setting for all [Equatable] instances.
   ///
   /// If [stringify] is overridden for a particular [Equatable] instance,
@@ -16,6 +17,7 @@ class EquatableConfig {
   /// over [EquatableConfig.stringify].
   ///
   /// This value defaults to true in debug mode and false in release mode.
+  /// {@endtemplate}
   static bool get stringify {
     if (_stringify == null) {
       assert(() {
@@ -26,6 +28,7 @@ class EquatableConfig {
     return _stringify ??= false;
   }
 
+  /// {@macro stringify}
   static set stringify(bool value) => _stringify = value;
 
   static bool? _stringify;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: A Dart package that helps to implement value based equality without needing to explicitly override == and hashCode.
-version: 2.0.0-nullsafety.3
+version: 2.0.0-nullsafety.4
 repository: https://github.com/felangel/equatable
 issue_tracker: https://github.com/felangel/equatable/issues
 homepage: https://github.com/felangel/equatable

--- a/test/equatable_config_test.dart
+++ b/test/equatable_config_test.dart
@@ -42,13 +42,19 @@ class CredentialsMixin extends EquatableBase {
 
 void main() {
   group('EquatableConfig', () {
+    late bool globalStringify;
+
+    setUp(() {
+      globalStringify = EquatableConfig.stringify;
+    });
+
     tearDown(() {
-      EquatableConfig.stringify = false;
+      EquatableConfig.stringify = globalStringify;
     });
 
     group('stringify', () {
-      test('defaults to false', () {
-        expect(EquatableConfig.stringify, isFalse);
+      test('defaults to true', () {
+        expect(EquatableConfig.stringify, isTrue);
       });
 
       test('is used when stringify is not overridden at the instance (false)',

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -123,14 +123,20 @@ class IterableWithFlag<T> extends Iterable<T> with EquatableMixin {
 }
 
 void main() {
+  late bool globalStringify;
+
   setUp(() {
-    EquatableConfig.stringify = false;
+    globalStringify = EquatableConfig.stringify;
+  });
+
+  tearDown(() {
+    EquatableConfig.stringify = globalStringify;
   });
 
   group('Empty Equatable', () {
     test('should correct toString', () {
       final instance = EmptyEquatable();
-      expect(instance.toString(), 'EmptyEquatable');
+      expect(instance.toString(), 'EmptyEquatable()');
     });
 
     test('should return true when instance is the same', () {
@@ -163,14 +169,13 @@ void main() {
   group('Simple Equatable (string)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>');
+      expect(instance.toString(), 'SimpleEquatable<String>(simple)');
     });
 
-    test('should correct toString when EquatableConfig.stringify is true', () {
-      EquatableConfig.stringify = true;
-      final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>(simple)');
+    test('should correct toString when EquatableConfig.stringify is false', () {
       EquatableConfig.stringify = false;
+      final instance = SimpleEquatable('simple');
+      expect(instance.toString(), 'SimpleEquatable<String>');
     });
 
     test('should return true when instance is the same', () {
@@ -215,7 +220,7 @@ void main() {
   group('Simple Equatable (number)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(0);
-      expect(instance.toString(), 'SimpleEquatable<int>');
+      expect(instance.toString(), 'SimpleEquatable<int>(0)');
     });
 
     test('should return true when instance is the same', () {
@@ -254,7 +259,7 @@ void main() {
   group('Simple Equatable (bool)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(true);
-      expect(instance.toString(), 'SimpleEquatable<bool>');
+      expect(instance.toString(), 'SimpleEquatable<bool>(true)');
     });
 
     test('should return true when instance is the same', () {
@@ -296,7 +301,10 @@ void main() {
         key: 'foo',
         value: 'bar',
       ));
-      expect(instance.toString(), 'SimpleEquatable<EquatableData>');
+      expect(
+        instance.toString(),
+        'SimpleEquatable<EquatableData>(EquatableData(foo, bar))',
+      );
     });
     test('should return true when instance is the same', () {
       final instance = SimpleEquatable(EquatableData(
@@ -355,7 +363,7 @@ void main() {
   group('Multipart Equatable', () {
     test('should correct toString', () {
       final instance = MultipartEquatable('s1', 's2');
-      expect(instance.toString(), 'MultipartEquatable<String>');
+      expect(instance.toString(), 'MultipartEquatable<String>(s1, s2)');
     });
 
     test('should return true when instance is the same', () {
@@ -410,7 +418,10 @@ void main() {
         hairColor: Color.black,
         children: ['Bob'],
       );
-      expect(instance.toString(), 'ComplexEquatable');
+      expect(
+        instance.toString(),
+        'ComplexEquatable(Joe, 40, Color.black, [Bob])',
+      );
     });
     test('should return true when instance is the same', () {
       final instance = ComplexEquatable(
@@ -506,7 +517,7 @@ void main() {
         }
         ''',
       ) as Map<String, dynamic>);
-      expect(instance.toString(), 'Credentials');
+      expect(instance.toString(), 'Credentials(Admin, admin)');
     });
 
     test('should return true when instance is the same', () {

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -240,7 +240,7 @@ void main() {
   });
 
   group('Simple Equatable (number)', () {
-    test('should correct toString', () {
+    test('should return correct toString', () {
       final instance = SimpleEquatable(0);
       expect(instance.toString(), 'SimpleEquatable<int>(0)');
     });

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -140,14 +140,20 @@ class ExplicitStringifyFalse extends Equatable {
 }
 
 void main() {
+  late bool globalStringify;
+
   setUp(() {
-    EquatableConfig.stringify = false;
+    globalStringify = EquatableConfig.stringify;
+  });
+
+  tearDown(() {
+    EquatableConfig.stringify = globalStringify;
   });
 
   group('Empty Equatable', () {
     test('should correct toString', () {
       final instance = EmptyEquatable();
-      expect(instance.toString(), 'EmptyEquatable');
+      expect(instance.toString(), 'EmptyEquatable()');
     });
 
     test('should return true when instance is the same', () {
@@ -180,14 +186,13 @@ void main() {
   group('Simple Equatable (string)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>');
+      expect(instance.toString(), 'SimpleEquatable<String>(simple)');
     });
 
-    test('should correct toString when EquatableConfig.stringify is true', () {
-      EquatableConfig.stringify = true;
-      final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>(simple)');
+    test('should correct toString when EquatableConfig.stringify is false', () {
       EquatableConfig.stringify = false;
+      final instance = SimpleEquatable('simple');
+      expect(instance.toString(), 'SimpleEquatable<String>');
     });
 
     test('should return true when instance is the same', () {
@@ -205,7 +210,7 @@ void main() {
 
     test('should return correct toString', () {
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>');
+      expect(instance.toString(), 'SimpleEquatable<String>(simple)');
     });
 
     test('should return true when instances are different', () {
@@ -237,7 +242,7 @@ void main() {
   group('Simple Equatable (number)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(0);
-      expect(instance.toString(), 'SimpleEquatable<int>');
+      expect(instance.toString(), 'SimpleEquatable<int>(0)');
     });
 
     test('should return true when instance is the same', () {
@@ -276,7 +281,7 @@ void main() {
   group('Simple Equatable (bool)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(true);
-      expect(instance.toString(), 'SimpleEquatable<bool>');
+      expect(instance.toString(), 'SimpleEquatable<bool>(true)');
     });
 
     test('should return true when instance is the same', () {
@@ -318,7 +323,10 @@ void main() {
         key: 'foo',
         value: 'bar',
       ));
-      expect(instance.toString(), 'SimpleEquatable<EquatableData>');
+      expect(
+        instance.toString(),
+        'SimpleEquatable<EquatableData>(EquatableData(foo, bar))',
+      );
     });
     test('should return true when instance is the same', () {
       final instance = SimpleEquatable(EquatableData(
@@ -377,7 +385,7 @@ void main() {
   group('Multipart Equatable', () {
     test('should correct toString', () {
       final instance = MultipartEquatable('s1', 's2');
-      expect(instance.toString(), 'MultipartEquatable<String>');
+      expect(instance.toString(), 'MultipartEquatable<String>(s1, s2)');
     });
 
     test('should return true when instance is the same', () {
@@ -432,7 +440,10 @@ void main() {
         hairColor: Color.black,
         children: ['Bob'],
       );
-      expect(instance.toString(), 'ComplexEquatable');
+      expect(
+        instance.toString(),
+        'ComplexEquatable(Joe, 40, Color.black, [Bob])',
+      );
     });
     test('should return true when instance is the same', () {
       final instance = ComplexEquatable(
@@ -544,7 +555,7 @@ void main() {
         }
         ''',
       ) as Map<String, dynamic>);
-      expect(instance.toString(), 'Credentials');
+      expect(instance.toString(), 'Credentials(Admin, admin)');
     });
 
     test('should return true when instance is the same', () {


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
YES

## Description
- `EquatableConfig.stringify` defaults to `true` in debug mode (closes #104)
  - `EquatableConfig.stringify` can still be set manually to override the default

## Todos
- [X] Tests
- [X] Documentation
- [X] Examples