### PR TITLE
fix: hashCode should be the same for equal objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- fix: `hashCode` should be the same for equal objects (`Map` fix)
+
 # 2.0.0
 
 - **BREAKING**: opt into null safety

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 
@@ -39,9 +41,11 @@ bool _isEquatable(dynamic object) {
 /// https://en.wikipedia.org/wiki/Jenkins_hash_function
 int _combine(int hash, dynamic object) {
   if (object is Map) {
-    object.forEach((dynamic key, dynamic value) {
-      hash = hash ^ _combine(hash, <dynamic>[key, value]);
-    });
+    SplayTreeMap<dynamic, dynamic>.of(object).forEach(
+      (dynamic key, dynamic value) {
+        hash = hash ^ _combine(hash, <dynamic>[key, value]);
+      },
+    );
     return hash;
   }
   if (object is Iterable) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable
 description: A Dart package that helps to implement value based equality without needing to explicitly override == and hashCode.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/felangel/equatable
 issue_tracker: https://github.com/felangel/equatable/issues
 homepage: https://github.com/felangel/equatable

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -317,6 +317,52 @@ void main() {
     });
   });
 
+  group('Simple Equatable (map)', () {
+    test('should correct toString', () {
+      final instance = SimpleEquatable(<String, dynamic>{});
+      expect(instance.toString(), 'SimpleEquatable<Map<String, dynamic>>({})');
+    });
+
+    test('should return true when instance is the same', () {
+      final instance = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should have same hashCode when values are equal', () {
+      final instanceA = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      final instanceB = SimpleEquatable({'b': 2, 'a': 1, 'c': 3});
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode, instanceB.hashCode);
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      final instanceB = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = SimpleEquatable({'a': 1, 'b': 2, 'c': 3});
+      final instanceB = SimpleEquatable({'a': 1, 'b': 2, 'c': 4});
+      expect(instanceA == instanceB, false);
+    });
+  });
+
   group('Simple Equatable (Equatable)', () {
     test('should correct toString', () {
       final instance = SimpleEquatable(EquatableData(


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
- fix: hashCode should be the same for equal objects (closes #114)
