### PR TITLE
Feat: Add derived object comparability

### DIFF
--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'equatable.dart';
 import 'equatable_config.dart';
 import 'equatable_utils.dart';
@@ -15,16 +17,45 @@ mixin EquatableMixin {
   // ignore: avoid_returning_null
   bool? get stringify => null;
 
+  /// {@macro equatable_derived}
+  Set<Type> get derived => {runtimeType};
+
   @override
   bool operator ==(Object other) {
-    return identical(this, other) ||
-        other is EquatableMixin &&
-            runtimeType == other.runtimeType &&
-            equals(props, other.props);
+    if (identical(this, other)) {
+      return true;
+    } else if (other is! EquatableMixin) {
+      return false;
+    }
+
+    final maxPosition = min(props.length, other.props.length);
+
+    final propsMatch = equals(
+      props.sublist(0, maxPosition),
+      other.props.sublist(0, maxPosition),
+    );
+
+    final isDerived = derived.intersection(other.derived).isNotEmpty;
+
+    return propsMatch && isDerived;
   }
 
   @override
   int get hashCode => runtimeType.hashCode ^ mapPropsToHashCode(props);
+
+  /// {@macro equatable_hash_code_from_super}
+  int hashCodeFromSuper(Object base) {
+    if (base is! EquatableMixin) {
+      return base.runtimeType.hashCode;
+    } else if (derived.intersection(base.derived).isEmpty) {
+      return base.runtimeType.hashCode;
+    }
+
+    final maxPosition = min(props.length, base.props.length);
+
+    return base.runtimeType.hashCode ^
+        mapPropsToHashCode(props.sublist(0, maxPosition));
+  }
 
   @override
   String toString() {

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -56,6 +56,54 @@ class ComplexEquatable extends EquatableBase {
   List<Object?> get props => [name, age, hairColor, children];
 }
 
+class DerivedComplexEquatable extends ComplexEquatable {
+  DerivedComplexEquatable({
+    String? name,
+    int? age,
+    Color? hairColor,
+    List<String>? children,
+    required this.isGood,
+  }) : super(
+          name: name,
+          age: age,
+          hairColor: hairColor,
+          children: children,
+        );
+
+  final bool isGood;
+
+  @override
+  Set<Type> get derived => {ComplexEquatable};
+
+  @override
+  List<Object?> get props => [...super.props, isGood];
+}
+
+class MultiDerivedComplexEquatable extends DerivedComplexEquatable {
+  MultiDerivedComplexEquatable({
+    String? name,
+    int? age,
+    Color? hairColor,
+    List<String>? children,
+    required bool isGood,
+    required this.isAlsoGood,
+  }) : super(
+          name: name,
+          age: age,
+          hairColor: hairColor,
+          children: children,
+          isGood: isGood,
+        );
+
+  final bool isAlsoGood;
+
+  @override
+  Set<Type> get derived => {...super.derived, DerivedComplexEquatable};
+
+  @override
+  List<Object?> get props => [...super.props, isAlsoGood];
+}
+
 class EquatableData extends EquatableBase {
   EquatableData({this.key, this.value});
 
@@ -504,6 +552,364 @@ void main() {
         children: [],
       );
       expect(instance.hashCode != instance2.hashCode, true);
+    });
+  });
+
+  group('Derived Complex Equatable', () {
+    test('should return true when instance is the same', () {
+      final instance = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return true when class is derived and super props match', () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+      expect(
+          instanceA.hashCode == instanceB.hashCodeFromSuper(instanceA), true);
+    });
+
+    test('should return false when class is derived and super props dont match',
+        () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test(
+        'should return false when class is derived '
+        'and super props only differ in list', () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'John',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in single property', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 41,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+  });
+
+  group('Multi Derived Complex Equatable', () {
+    test('should return true when instance is the same', () {
+      final instance = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return true when class is derived and super props match', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+      expect(
+        instanceA.hashCode == instanceB.hashCodeFromSuper(instanceA),
+        true,
+      );
+    });
+
+    test('should return false when class is derived and super props dont match',
+        () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test(
+        'should return false when class is derived '
+        'and super props only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'John',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: false,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in single property', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: false,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
     });
   });
 

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -60,6 +60,54 @@ class ComplexEquatable extends Equatable {
   List<Object?> get props => [name, age, hairColor, children];
 }
 
+class DerivedComplexEquatable extends ComplexEquatable {
+  const DerivedComplexEquatable({
+    String? name,
+    int? age,
+    Color? hairColor,
+    List<String>? children,
+    required this.isGood,
+  }) : super(
+          name: name,
+          age: age,
+          hairColor: hairColor,
+          children: children,
+        );
+
+  final bool isGood;
+
+  @override
+  Set<Type> get derived => {ComplexEquatable};
+
+  @override
+  List<Object?> get props => [...super.props, isGood];
+}
+
+class MultiDerivedComplexEquatable extends DerivedComplexEquatable {
+  const MultiDerivedComplexEquatable({
+    String? name,
+    int? age,
+    Color? hairColor,
+    List<String>? children,
+    required bool isGood,
+    required this.isAlsoGood,
+  }) : super(
+          name: name,
+          age: age,
+          hairColor: hairColor,
+          children: children,
+          isGood: isGood,
+        );
+
+  final bool isAlsoGood;
+
+  @override
+  Set<Type> get derived => {...super.derived, DerivedComplexEquatable};
+
+  @override
+  List<Object?> get props => [...super.props, isAlsoGood];
+}
+
 class EquatableData extends Equatable {
   const EquatableData({required this.key, required this.value});
 
@@ -477,6 +525,7 @@ void main() {
         'SimpleEquatable<EquatableData>(EquatableData(foo, bar))',
       );
     });
+
     test('should return true when instance is the same', () {
       final instance = SimpleEquatable(EquatableData(
         key: 'foo',
@@ -689,6 +738,362 @@ void main() {
         age: 41,
         hairColor: Color.black,
         children: ['Bob'],
+      );
+      expect(instanceA == instanceB, false);
+    });
+  });
+
+  group('Derived Complex Equatable', () {
+    test('should return true when instance is the same', () {
+      final instance = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return true when class is derived and super props match', () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+      expect(
+          instanceA.hashCode == instanceB.hashCodeFromSuper(instanceA), true);
+    });
+
+    test('should return false when class is derived and super props dont match',
+        () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test(
+        'should return false when class is derived '
+        'and super props only differ in list', () {
+      final instanceA = ComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'John',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in single property', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 41,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+  });
+
+  group('Multi Derived Complex Equatable', () {
+    test('should return true when instance is the same', () {
+      final instance = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return true when class is derived and super props match', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+      expect(
+          instanceA.hashCode == instanceB.hashCodeFromSuper(instanceA), true);
+    });
+
+    test('should return false when class is derived and super props dont match',
+        () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test(
+        'should return false when class is derived '
+        'and super props only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+      expect(instanceA.hashCode == instanceB.hashCode, false);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'John',
+        age: 40,
+        hairColor: Color.brown,
+        children: ['Bobby'],
+        isGood: false,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in list', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bobby'],
+        isGood: true,
+        isAlsoGood: true,
+      );
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values only differ in single property', () {
+      final instanceA = DerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: true,
+      );
+      final instanceB = MultiDerivedComplexEquatable(
+        name: 'Joe',
+        age: 40,
+        hairColor: Color.black,
+        children: ['Bob'],
+        isGood: false,
+        isAlsoGood: true,
       );
       expect(instanceA == instanceB, false);
     });


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Breaking Changes
NO

## Description
When comparing derived (sub) classes to it's base class, the result it always `false`. I would expect that, if the base props matches the derived class's base props, the result would be `true`. 

## Todos
- [x] Tests
- [x] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```dart
import 'package:equatable/equatable.dart';

class A extends Equatable {
  const A(this.value);
  final String value;

  @override
  List<Object?> get props => [value];
}

class B extends A {
  const B(String a, this.code) : super(a);
  final int code;

  @override
  List<Object?> get props => [...super.props, code];

  @override
  Set<Type> get derived => {A};
}

class C extends B {
  const C(
    String value,
    int code, {
    required this.isCool,
  }) : super(value, code);

  final bool isCool;

  @override
  Set<Type> get derived => {B, ...super.derived};

  @override
  List<Object?> get props => [...super.props, isCool];
}

void main() {
  final notEqualA = const A('not-equal');

  final instanceA = const A('a');
  final instanceB = const B('a', 1);
  final instanceC = const C('a', 1, isCool: true);

  print(notEqualA == instanceA); // false

  print(instanceA == instanceB); // true
  print(instanceA == instanceC); // true

  print(instanceB == instanceA); // true
  print(instanceB == instanceC); // true

  print(instanceC == instanceA); // true
  print(instanceC == instanceB); // true

  // reversed
  print(instanceB == instanceA); // true
  print(instanceC == instanceA); // true

  print(instanceA == instanceB); // true
  print(instanceC == instanceB); // true

  print(instanceA == instanceC); // true
  print(instanceB == instanceC); // true
}
```

## Impact to Remaining Code Base
This PR will affect:

* This should have no impact on the Code Base

## Possible Concerns
By manipulating the `==` to match derivatives from the base class, the `hashCode` will not return the same result as the `==` operator. *This only occurs when `derived` is overridden, otherwise the results ARE the same.* 

[HashCode Docs](https://api.flutter.dev/flutter/dart-core/Object/hashCode.html)

```dart
/*
Base:        instanceA
Derivative:  instanceB
*/

print(instanceA == instanceB); // true
print(instanceA.hashCode == instanceB.hashCode); // false
```
