### PR TITLE
Update README.md to use List<Object?>

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ class Person extends Equatable {
   final String name;
 
   @override
-  List<Object> get props => [name];
+  List<Object?> get props => [name];
 }
 ```
 
@@ -147,7 +147,7 @@ class Person extends Equatable {
   final String name;
 
   @override
-  List<Object> get props => [name];
+  List<Object?> get props => [name];
 
   factory Person.fromJson(Map<String, dynamic> json) {
     return Person(json['name']);
@@ -169,7 +169,7 @@ class Person extends Equatable {
   final String name;
 
   @override
-  List<Object> get props => [name];
+  List<Object?> get props => [name];
 }
 ```
 
@@ -254,7 +254,7 @@ class Person extends Equatable {
   final String name;
 
   @override
-  List<Object> get props => [name];
+  List<Object?> get props => [name];
 }
 ```
 
@@ -281,7 +281,7 @@ class EquatableDateTime extends DateTime with EquatableMixin {
   ]) : super(year, month, day, hour, minute, second, millisecond, microsecond);
 
   @override
-  List<Object> get props {
+  List<Object?> get props {
     return [year, month, day, hour, minute, second, millisecond, microsecond];
   }
 }
@@ -306,7 +306,7 @@ class EquatableDateTimeSubclass extends EquatableDateTime {
   ]) : super(year, month, day, hour, minute, second, millisecond, microsecond);
 
   @override
-  List<Object> get props => super.props..addAll([century]);
+  List<Object?> get props => super.props..addAll([century]);
 }
 ```
 


### PR DESCRIPTION
I tried to add Equatable to a class I have according to the readme, and it failed because I had a nullable field.
Replacing `List<Object>` with `List<Object?>` fixed the problem. So I suggest to change the readme.

The actual overridden property is indeed `List<Object?> get props`, so I think there's no need to restrict it to non-nullable values.

## Status
**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes
YES | NO

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
```

## Impact to Remaining Code Base
This PR will affect:

* 
