### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class Person {
 }
 ```
 
-We can create create instances of `Person` like so:
+We can create instances of `Person` like so:
 
 ```dart
 void main() {


### PR DESCRIPTION
Remove the duplicate 'create' from the README.

## Status
**READY**

## Breaking Changes
NO

## Description
Fix typo in README.

## Related PRs
N/A

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```
View the README.
```

## Impact to Remaining Code Base
This PR will affect:

* Documentation
