### PR TITLE
refactor: simplify `toString` logic

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -54,15 +54,9 @@ abstract class Equatable {
 
   @override
   String toString() {
-    switch (stringify) {
-      case true:
-        return mapPropsToString(runtimeType, props);
-      case false:
-        return '$runtimeType';
-      default:
-        return EquatableConfig.stringify == true
-            ? mapPropsToString(runtimeType, props)
-            : '$runtimeType';
+    if (stringify ?? EquatableConfig.stringify) {
+      return mapPropsToString(runtimeType, props);
     }
+    return '$runtimeType';
   }
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -31,15 +31,9 @@ mixin EquatableMixin {
 
   @override
   String toString() {
-    switch (stringify) {
-      case true:
-        return mapPropsToString(runtimeType, props);
-      case false:
-        return '$runtimeType';
-      default:
-        return EquatableConfig.stringify == true
-            ? mapPropsToString(runtimeType, props)
-            : '$runtimeType';
+    if (stringify ?? EquatableConfig.stringify) {
+      return mapPropsToString(runtimeType, props);
     }
+    return '$runtimeType';
   }
 }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
The goal is to simplify toString method on `Equatable` and `EquatableMixin` and remove repetitive logic.