### PR TITLE
fix: use SplayTreeSet to resolve inconsistent hashCode

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,4 +48,4 @@ jobs:
           PANA=$(pana . --no-warning); PANA_SCORE=$(echo $PANA | sed -n "s/.*Points: \([0-9]*\)\/\([0-9]*\)./\1\/\2/p")
           echo "score: $PANA_SCORE"
           IFS='/'; read -a SCORE_ARR <<< "$PANA_SCORE"; SCORE=SCORE_ARR[0]; TOTAL=SCORE_ARR[1]
-          if (( $SCORE < $TOTAL )); then echo "minimum score not met!"; exit 1; fi
+          if (( $SCORE < $TOTAL )); then echo $PANA; echo "minimum score not met!"; exit 1; fi

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -48,7 +48,7 @@ int _combine(int hash, dynamic object) {
     });
     return hash;
   }
-  if (object is Set) {
+  if (object is Set && object is! SplayTreeSet) {
     // this is needed to have a consistent iteration order so that the produced
     // hash is consistent independently of the Set insertion order
     object = SplayTreeSet<dynamic>.from(object);

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 
@@ -45,6 +47,11 @@ int _combine(int hash, dynamic object) {
       hash = hash ^ _combine(hash, <dynamic>[key, object[key]]);
     });
     return hash;
+  }
+  if(object is Set) {
+    // this is needed to have a consistent iteration order so that the produced
+    // hash is consistent independently of the Set insertion order
+    object = SplayTreeSet<dynamic>.from(object);
   }
   if (object is Iterable) {
     for (final value in object) {

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -48,7 +48,7 @@ int _combine(int hash, dynamic object) {
     });
     return hash;
   }
-  if(object is Set) {
+  if (object is Set) {
     // this is needed to have a consistent iteration order so that the produced
     // hash is consistent independently of the Set insertion order
     object = SplayTreeSet<dynamic>.from(object);

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -968,6 +968,17 @@ void main() {
         expect(instanceA.hashCode == instanceB.hashCode, true);
       });
 
+      test('should return when Set values are same but in different order', () {
+        final instanceA = SimpleEquatable<Set<String>>(
+          Set.from(<String>['A', 'B']),
+        );
+        final instanceB = SimpleEquatable<Set<String>>(
+          Set.from(<String>['B', 'A']),
+        );
+        expect(instanceA == instanceB, true);
+        expect(instanceA.hashCode == instanceB.hashCode, true);
+      });
+
       test('should return when values are different', () {
         final instanceA = SimpleEquatable<Set<String>>(
           Set.from(<String>['A', 'B']),


### PR DESCRIPTION
Fixes #141

## Status
**READY**

## Breaking Changes
NO

## Description
This fixes the inconsistent hashCode behaviour for Sets by using a SplayTreeSet to ensure a consistent iteration order.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
See #141

## Impact to Remaining Code Base
None known