### PR TITLE
fetch all list of properties dynamic

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -13,7 +13,7 @@ import './equatable_utils.dart';
 ///   final String name;
 ///
 ///   @override
-///   List<Object> get props => [name];
+///   List<Object?> get props => [name];
 /// }
 /// ```
 /// {@endtemplate}

--- a/lib/src/equatable_extension.dart
+++ b/lib/src/equatable_extension.dart
@@ -1,0 +1,41 @@
+import 'dart:mirrors';
+
+import 'package:equatable/equatable.dart';
+
+/// {@template equatable}
+/// A extension class with method fetch all list of properties dynamic.
+///
+/// ```dart
+/// class Person extends Equatable {
+///   const Person(this.name);
+///
+///   final String name;
+///
+///   @override
+///   List<Object?> get props => fetchProperties();
+/// }
+/// ```
+/// {@endtemplate}
+extension EquatableExtension on Equatable {
+  /// {@template equatable_props}
+  /// Fetch all list of properties that will be used to determine whether
+  /// two instances are equal.
+  /// Note: The dart:mirrors library is unstable.
+  /// {@endtemplate}
+  List<Object?> fetchProperties() {
+    final instanceMirror = reflect(this);
+    final classMirror = instanceMirror.type;
+    final properties = <Object?>[];
+
+    for (final declarationMirror in classMirror.declarations.values) {
+      if (declarationMirror is VariableMirror) {
+        final field = instanceMirror.getField(declarationMirror.simpleName);
+        if (field.hasReflectee) {
+          properties.add(field.reflectee);
+        }
+      }
+    }
+
+    return properties;
+  }
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

### current approach
```dart
class Person extends Equatable {
  const Person(this.name);

  final String? name;

  @override
  List<Object?> get props => [name];
}
```
When I implement `props`, I must do it manually. 

If class `Person` has more than one attribute then I write a lot of code, 
I wonder is it possible to do it automatically?

### new approach

```dart
class Person extends Equatable {
  const Person(this.name);

  final String? name;

  @override
  List<Object?> get props => fetchProperties();
}
```

I created method `fetchProperties` from `EquatableExtension`. 
The method will return all lists of properties dynamic.

The idea from this [post](https://ttpho.github.io/2022-07-31-to-map-dynamic/),  I use `dart:mirrors` library.

```dart 
List<Object?> list = <Object?>[];
Object -> InstanceMirror -> ClassMirror -> declarations.values -> List<DeclarationMirror>
for v in  List<DeclarationMirror>
  v is VariableMirror
    filedValue <- v
    list.add(filedValue)
```

### Note 

The `dart:mirrors` library is unstable

### Self test 

```dart 
class Person extends Equatable {
  const Person(this.name);

  final String? name;

  @override
  List<Object?> get props => fetchProperties();
}

class Group extends Equatable {
  const Group(this.persons);

  final List<Person> persons;

  @override
  List<Object?> get props => fetchProperties();
}

void main(List<String> arguments) {
  final Person person1 = Person("ttpho");
  final Person person2 = Person("ttpho");
  print(person1 == person1); // true
  print(person1 == person2); // true

  final Group group1 = Group([person1]);
  final Group group2 = Group([person2]);

  print(group1 == group1); // true
  print(group1 == group2); // true
}
```

## Related PRs

## Todos

## Steps to Test or Reproduce

## Impact to Remaining Code Base

