### PR TITLE
Fix NPE on toString with null prop

### DIFF
--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -69,4 +69,6 @@ int _finish(int hash) {
 
 /// Returns a string for [props].
 String mapPropsToString(Type runtimeType, List<Object?> props) =>
-    '$runtimeType(${props.map((prop) => prop.toString()).join(', ')})';
+    '$runtimeType(${props.map((prop) {
+      return prop?.toString() ?? 'null';
+    }).join(', ')})';


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
When a property is null and toString is invoked, a NPE is throw