### PR TITLE
feat: support stringifyProps

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -31,6 +31,10 @@ class EquatableDateTime extends DateTime with EquatableMixin {
   }
 
   @override
+  List<Object?>? get stringifyProps =>
+      [year, month, day, hour, minute, second, millisecond, microsecond];
+
+  @override
   bool get stringify => true;
 }
 

--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -28,6 +28,12 @@ abstract class Equatable {
   /// {@endtemplate}
   List<Object?> get props;
 
+  /// {@template equatable_stringifyProps}
+  /// The list of properties that will be used to print the properties of
+  /// instance
+  /// {@endtemplate}
+  List<Object?>? get stringifyProps => null;
+
   /// {@template equatable_stringify}
   /// If set to `true`, the [toString] method will be overridden to output
   /// this instance's [props].
@@ -56,12 +62,12 @@ abstract class Equatable {
   String toString() {
     switch (stringify) {
       case true:
-        return mapPropsToString(runtimeType, props);
+        return mapPropsToString(runtimeType, stringifyProps ?? props);
       case false:
         return '$runtimeType';
       default:
         return EquatableConfig.stringify == true
-            ? mapPropsToString(runtimeType, props)
+            ? mapPropsToString(runtimeType, stringifyProps ?? props)
             : '$runtimeType';
     }
   }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -14,6 +14,9 @@ mixin EquatableMixin {
   /// {@macro equatable_props}
   List<Object?> get props;
 
+  /// {@macro equatable_stringifyProps}
+  List<Object?>? get stringifyProps => null;
+
   /// {@macro equatable_stringify}
   // ignore: avoid_returning_null
   bool? get stringify => null;
@@ -33,12 +36,12 @@ mixin EquatableMixin {
   String toString() {
     switch (stringify) {
       case true:
-        return mapPropsToString(runtimeType, props);
+        return mapPropsToString(runtimeType, stringifyProps ?? props);
       case false:
         return '$runtimeType';
       default:
         return EquatableConfig.stringify == true
-            ? mapPropsToString(runtimeType, props)
+            ? mapPropsToString(runtimeType, stringifyProps ?? props)
             : '$runtimeType';
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/felangel/equatable
 documentation: https://github.com/felangel/equatable
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.2 <4.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -171,6 +171,25 @@ class PartialStringifyProps extends Equatable {
   List<Object?>? get stringifyProps => [name];
 }
 
+class PartialStringifyWithStringifyFalse extends Equatable {
+  const PartialStringifyWithStringifyFalse({
+    required this.name,
+    required this.age,
+  });
+
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  @override
+  List<Object?>? get stringifyProps => [name, age];
+
+  @override
+  bool? get stringify => false;
+}
+
 void main() {
   late bool globalStringify;
 
@@ -1084,6 +1103,17 @@ void main() {
       expect(instanceB.toString(), 'ExplicitStringifyFalse');
       expect(instanceC.toString(), 'ExplicitStringifyFalse');
     });
+
+    test(
+      'with PartialStringifyWithStringifyFalse stringify ',
+      () async {
+        final instance = PartialStringifyWithStringifyFalse(
+          name: 'John',
+          age: 1,
+        );
+        expect(instance.toString(), 'PartialStringifyWithStringifyFalse');
+      },
+    );
   });
 
   group('Equatable with all custom stringify Props', () {

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -1169,6 +1169,15 @@ void main() {
       );
       expect(instanceA == instanceB, false);
     });
+
+    test('should correct toString when EquatableConfig.stringify is false', () {
+      EquatableConfig.stringify = false;
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance.toString(), 'CompleteStringifyProps');
+    });
   });
 
   group('Equatable with partial custom stringify Props', () {
@@ -1251,6 +1260,15 @@ void main() {
         age: 2,
       );
       expect(instanceA == instanceB, false);
+    });
+
+    test('should correct toString when EquatableConfig.stringify is false', () {
+      EquatableConfig.stringify = false;
+      final instance = PartialStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance.toString(), 'PartialStringifyProps');
     });
   });
 }

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -139,6 +139,38 @@ class ExplicitStringifyFalse extends Equatable {
   bool get stringify => false;
 }
 
+class CompleteStringifyProps extends Equatable {
+  const CompleteStringifyProps({
+    required this.name,
+    required this.age,
+  });
+
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  @override
+  List<Object?>? get stringifyProps => [name, age];
+}
+
+class PartialStringifyProps extends Equatable {
+  const PartialStringifyProps({
+    required this.name,
+    required this.age,
+  });
+
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  @override
+  List<Object?>? get stringifyProps => [name];
+}
+
 void main() {
   late bool globalStringify;
 
@@ -1051,6 +1083,174 @@ void main() {
       expect(instanceA.toString(), 'ExplicitStringifyFalse');
       expect(instanceB.toString(), 'ExplicitStringifyFalse');
       expect(instanceC.toString(), 'ExplicitStringifyFalse');
+    });
+  });
+
+  group('Equatable with all custom stringify Props', () {
+    test(
+      'should correct toString',
+      () async {
+        final instance = CompleteStringifyProps(
+          name: 'John',
+          age: 1,
+        );
+
+        expect(instance.toString(), 'CompleteStringifyProps(John, 1)');
+      },
+    );
+
+    test('should correct toString when EquatableConfig.stringify is false', () {
+      EquatableConfig.stringify = false;
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance.toString(), 'CompleteStringifyProps');
+    });
+
+    test('should return true when instance is the same', () {
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when compared to different equatable', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = OtherEquatable('simple');
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = CompleteStringifyProps(
+        name: 'John',
+        age: 2,
+      );
+      expect(instanceA == instanceB, false);
+    });
+  });
+
+  group('Equatable with partial custom stringify Props', () {
+    test(
+      'should print correct toString based on stringifyProps',
+      () async {
+        final instance = PartialStringifyProps(
+          name: 'John',
+          age: 1,
+        );
+        expect(instance.toString(), 'PartialStringifyProps(John)');
+      },
+    );
+    test('should correct toString when EquatableConfig.stringify is false', () {
+      EquatableConfig.stringify = false;
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance.toString(), 'CompleteStringifyProps');
+    });
+
+    test('should return true when instance is the same', () {
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instance == instance, true);
+    });
+
+    test('should return correct hashCode', () {
+      final instance = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(
+        instance.hashCode,
+        instance.runtimeType.hashCode ^ mapPropsToHashCode(instance.props),
+      );
+    });
+
+    test('should return true when instances are different', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      expect(instanceA == instanceB, true);
+      expect(instanceA.hashCode == instanceB.hashCode, true);
+    });
+
+    test('should return false when compared to non-equatable', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = NonEquatable();
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when compared to different equatable', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = OtherEquatable('simple');
+      expect(instanceA == instanceB, false);
+    });
+
+    test('should return false when values are different', () {
+      final instanceA = CompleteStringifyProps(
+        name: 'John',
+        age: 1,
+      );
+      final instanceB = CompleteStringifyProps(
+        name: 'John',
+        age: 2,
+      );
+      expect(instanceA == instanceB, false);
     });
   });
 }


### PR DESCRIPTION


## Status
**READY**

## Breaking Changes
NO

## Description
This PR allows user to provide custom stringify props which will be used in toString() method.
Before this making stringify=>True; prints all the member which is not required always.

## Todos
- [x] Tests
- [x] Documentation
- [x] Examples

## Steps to Test

```
class PartialStringifyProps extends Equatable {
  const PartialStringifyProps({
    required this.name,
    required this.age,
  });

  final String name;
  final int age;

  @override
  List<Object?> get props => [name, age];

  @override
  List<Object?>? get stringifyProps => [name];
}

 final instance = PartialStringifyProps(
          name: 'John',
          age: 1,
);
print(instance.toString());
// PartialStringifyProps(John)
```
