### PR TITLE
fix: don't test for runtimeType equality for object comparison

### DIFF
--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -53,8 +53,6 @@ bool objectsEquals(Object? a, Object? b) {
     return iterableEquals(a, b);
   } else if (a is Map && b is Map) {
     return mapEquals(a, b);
-  } else if (a?.runtimeType != b?.runtimeType) {
-    return false;
   } else if (a != b) {
     return false;
   }

--- a/test/equatable_utils_test.dart
+++ b/test/equatable_utils_test.dart
@@ -245,6 +245,12 @@ void main() {
       expect(objectsEquals(bob, alice), isFalse);
     });
 
+    test('returns true for int and double in a num variable', () {
+      const num intNum = 0;
+      const num doubleNum = 0.0;
+      expect(objectsEquals(intNum, doubleNum), isTrue);
+    });
+
     test('returns true for same lists', () {
       expect(objectsEquals([1, 2, 3], [1, 2, 3]), isTrue);
     });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
This PR fixes an issue introduced with 2.0.6 that int and double num values are no longer treated as equal (like 0 != 0.0)

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Have an equatable class with a num field.
Create two instances, set the num field to `0` on the first instance and to `0.0` on the second instance.
Test equality.
```dart
instance1.numField = 0;
instance2.numField = 0.0;

assert(instance1 == instance2); //breaks with 2.0.6
```

## Impact to Remaining Code Base
Should be fine