### PR TITLE
fix: don't test for runtimeType equality for object comparison take 2

### DIFF
--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -53,8 +53,6 @@ bool objectsEquals(Object? a, Object? b) {
     return iterableEquals(a, b);
   } else if (a is Map && b is Map) {
     return mapEquals(a, b);
-  } else if (a?.runtimeType != b?.runtimeType) {
-    return false;
   } else if (a != b) {
     return false;
   }

--- a/test/equatable_utils_test.dart
+++ b/test/equatable_utils_test.dart
@@ -393,12 +393,6 @@ void main() {
       );
     });
 
-    test('returns true for int and double in a num variable', () {
-      const num intNum = 0;
-      const num doubleNum = 0.0;
-      expect(objectsEquals(intNum, doubleNum), isTrue);
-    });
-
     test('returns true for same lists', () {
       expect(objectsEquals([1, 2, 3], [1, 2, 3]), isTrue);
     });

--- a/test/equatable_utils_test.dart
+++ b/test/equatable_utils_test.dart
@@ -366,6 +366,7 @@ void main() {
         isTrue,
       );
     });
+
     test(
         'returns false for Equatables with custom equality members '
         'that are not equal and have a different runtimeType', () {
@@ -389,6 +390,23 @@ void main() {
 
     test('returns true for same lists', () {
       expect(objectsEquals([1, 2, 3], [1, 2, 3]), isTrue);
+    });
+
+    test(
+        'returns true for List of custom equality objects '
+        'that are equal but have a different runtimeType', () {
+      const nameSimple = SimpleName('fluffy');
+      const namePedigree = PedigreeName(prefix: '', name: 'Fluffy', suffix: '');
+      //cross check
+      expect(nameSimple == namePedigree, isTrue);
+      //actual check
+      expect(
+        objectsEquals(
+          [nameSimple],
+          [namePedigree],
+        ),
+        isTrue,
+      );
     });
 
     test('returns true for same sets', () {

--- a/test/equatable_utils_test.dart
+++ b/test/equatable_utils_test.dart
@@ -245,6 +245,12 @@ void main() {
       expect(objectsEquals(bob, alice), isFalse);
     });
 
+    test('returns true for int and double in a num variable', () {
+      const num intNum = 0;
+      const num doubleNum = 0.0;
+      expect(objectsEquals(intNum, doubleNum), isTrue);
+    });
+
     test('returns true for same lists', () {
       expect(objectsEquals([1, 2, 3], [1, 2, 3]), isTrue);
     });


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Continuation of #188 
As discussed in the referenced PR here an extended PR that adds a couple of tests to make sure that Equatable comparison still works as intended (e.g. different classes with same property values should be different) as well as adding a ~~very far-fetched~~ test-case that simulates non-Equatable classes with custom equality logic.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
master | [link](https://github.com/felangel/equatable/pull/188)


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Examples

## Steps to Test or Reproduce
Have an Equatable class with a field that's type is using a custom equality logic

```
class CustomEqualityVariant1;
class CustomEqualityVariant2;

final val1 = CustomEqualityVariant1();
final val2 = CustomEqualityVariant2();
val1 == val2

final equatableInstance1 = EquatableClass(val1);
final equatableInstance2 = EquatableClass(val2);

instance1 != instance2 // this was not the case pre 2.0.6
```

## Impact to Remaining Code Base
This PR will affect:

* !behavior change! will increase the set of equal==true combinations compared to 2.0.7 and 2.0.5 (all props that have a different runtimeType but are equal are now treated as equal)
* restores 2.0.5 behavior for Equatable props of type List<BaseClass> with different SubClass variants that are equal without sharing the same runtimeType
