### PR TITLE
feat: support Set equality comparison in iterableEquals

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -46,7 +46,7 @@ abstract class Equatable {
     return identical(this, other) ||
         other is Equatable &&
             runtimeType == other.runtimeType &&
-            iterableEquals(props, other.props);
+            propsEquals(props, other.props);
   }
 
   @override

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -22,7 +22,7 @@ mixin EquatableMixin {
     return identical(this, other) ||
         other is EquatableMixin &&
             runtimeType == other.runtimeType &&
-            iterableEquals(props, other.props);
+            propsEquals(props, other.props);
   }
 
   @override

--- a/lib/src/equatable_utils.dart
+++ b/lib/src/equatable_utils.dart
@@ -15,6 +15,17 @@ bool equals(List<Object?>? a, List<Object?>? b) {
   return iterableEquals(a, b);
 }
 
+/// Determines whether two props list are equal.
+@pragma('vm:prefer-inline')
+bool propsEquals(List<Object?> a, List<Object?> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (!objectsEquals(a.elementAt(i), b.elementAt(i))) return false;
+  }
+  return true;
+}
+
 /// Determines whether two iterables are equal.
 @pragma('vm:prefer-inline')
 bool iterableEquals(Iterable<Object?> a, Iterable<Object?> b) {
@@ -88,8 +99,8 @@ int _combine(int hash, Object? object) {
     object.keys
         .sorted((Object? a, Object? b) => a.hashCode - b.hashCode)
         .forEach((Object? key) {
-          hash = hash ^ _combine(hash, [key, (object! as Map)[key]]);
-        });
+      hash = hash ^ _combine(hash, [key, (object! as Map)[key]]);
+    });
     return hash;
   }
   if (object is Set) {

--- a/test/equatable_utils_test.dart
+++ b/test/equatable_utils_test.dart
@@ -11,6 +11,10 @@ class Person with EquatableMixin {
   List<Object?> get props => [name];
 }
 
+extension IterableConverter<T> on Iterable<T> {
+  Iterable<T> toIterable() => map((e) => e);
+}
+
 void main() {
   final bob = Person(name: 'Bob');
   final alice = Person(name: 'Alice');
@@ -31,18 +35,52 @@ void main() {
     test('returns true for identical props', () {
       final value = [Object()];
       expect(iterableEquals(value, value), isTrue);
+      expect(iterableEquals(value.toSet(), value.toSet()), isTrue);
+      expect(iterableEquals(value.toIterable(), value.toIterable()), isTrue);
       expect(equals(value, value), isTrue);
     });
 
     test('returns true for empty iterables', () {
       expect(iterableEquals([], []), isTrue);
+      expect(iterableEquals({}, {}), isTrue);
+      // ignore: prefer_const_constructors
+      expect(iterableEquals(Iterable.empty(), Iterable.empty()), isTrue);
       expect(equals([], []), isTrue);
     });
 
     test('returns false when props differ in length', () {
       final object = Object();
       expect(iterableEquals([object], [object, object]), isFalse);
+      expect(iterableEquals({object}, {object, null}), isFalse);
+      expect(
+        iterableEquals([object].toIterable(), [object, object].toIterable()),
+        isFalse,
+      );
       expect(equals([object], [object, object]), isFalse);
+    });
+
+    test('returns false when comparing a List to a non-List Iterable', () {
+      final list = [Object()];
+      expect(iterableEquals(list, list.toSet()), isFalse);
+      expect(iterableEquals(list, list.toIterable()), isFalse);
+    });
+
+    test('returns false when comparing a Set to a non-Set Iterable', () {
+      final set = {Object()};
+      expect(iterableEquals(set, set.toList()), isFalse);
+      expect(iterableEquals(set, set.toIterable()), isFalse);
+    });
+
+    test('returns false when comparing a Iterable to a Set or a List', () {
+      final iterable = Iterable.generate(1, (_) => Object());
+      expect(iterableEquals(iterable, iterable.toList()), isFalse);
+      expect(iterableEquals(iterable, iterable.toSet()), isFalse);
+    });
+
+    test('returns false when comparing a List to a non-List Iterable', () {
+      final object = Object();
+      expect(iterableEquals([object], {object}), isFalse);
+      expect(iterableEquals([object], [object].toIterable()), isFalse);
     });
 
     test('uses == when props are equatable', () {
@@ -63,11 +101,15 @@ void main() {
       final iterable1 = [1, 2, 3];
       final iterable2 = [1, 2, 4];
       expect(iterableEquals(iterable1, iterable2), isFalse);
+      expect(iterableEquals(iterable1.toSet(), iterable2.toSet()), isFalse);
+      expect(
+        iterableEquals(iterable1.toIterable(), iterable2.toIterable()),
+        isFalse,
+      );
       expect(equals(iterable1, iterable2), isFalse);
     });
 
-    test(
-        'returns false for iterable with same elements '
+    test('returns false for iterable with same elements '
         'but different order', () {
       final iterable1 = [1, 2, 3];
       final iterable2 = [1, 3, 2];
@@ -76,29 +118,33 @@ void main() {
     });
 
     test('returns true for nested identical iterables', () {
-      final iterable1 = [
+      final list1 = [
         [bob, alice],
         [alice, bob],
       ];
-      final iterable2 = [
+      final list2 = [
         [bob, alice],
         [alice, bob],
       ];
-      expect(iterableEquals(iterable1, iterable2), isTrue);
-      expect(equals(iterable1, iterable2), isTrue);
+      expect(iterableEquals(list1, list2), isTrue);
+      expect(iterableEquals(list1.toSet(), list2.toSet()), isTrue);
+      expect(iterableEquals(list1.toIterable(), list2.toIterable()), isTrue);
+      expect(equals(list1, list2), isTrue);
     });
 
     test('returns false for nested iterables with different elements', () {
-      final iterable1 = [
+      final list1 = [
         [bob, 2],
         [3, 4],
       ];
-      final iterable2 = [
+      final list2 = [
         [bob, 2],
         [3, 5],
       ];
-      expect(iterableEquals(iterable1, iterable2), isFalse);
-      expect(equals(iterable1, iterable2), isFalse);
+      expect(iterableEquals(list1, list2), isFalse);
+      expect(iterableEquals(list1.toSet(), list2.toSet()), isFalse);
+      expect(iterableEquals(list1.toIterable(), list2.toIterable()), isFalse);
+      expect(equals(list1, list2), isFalse);
     });
   });
 
@@ -109,12 +155,14 @@ void main() {
       expect(setEquals(set1, set2), isTrue);
     });
 
-    test('returns true for identical sets with elements in different order',
-        () {
-      final set1 = {1, 3, 2};
-      final set2 = {1, 2, 3};
-      expect(setEquals(set1, set2), isTrue);
-    });
+    test(
+      'returns true for identical sets with elements in different order',
+      () {
+        final set1 = {1, 3, 2};
+        final set2 = {1, 2, 3};
+        expect(setEquals(set1, set2), isTrue);
+      },
+    );
 
     test('returns false for sets of different lengths', () {
       final set1 = {1, 2, 3};


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Breaking Changes
YES

## Description
Add support for equality comparison between all types of Iterable including Sets to `iterableEquals` and subsequently all Equatable objects.
Additionally, a `propsEquals` function which compares the `List<Object?>` props is added and used in operator == override for Equatable and EquatableMixin in place of iterableEquals to skip the newly added checks and maintain similar performance in the existing benchmarks.

Fixes #196 

## Impact to Remaining Code Base
This PR will affect:

* Equality checking between non-Set Iterable and Set.
  - returns false instead of throwing AssertionError
* Equality checking between a List and a Iterable of equal elements in same order.
  - returns false instead of true

<details>
<summary>Benchmarks result from before and after</summary>

### EmptyEquatable
| stat          | Before      | After       |
| ------------- | ----------- | ----------- |
| total runs    | 1 759 499   | 1 743 908   |
| total time    | 2.0000  s   | 2.0000  s   |
| average run   | 1 μs        | 1 μs        |
| runs/second   | 1 000 000   | 1 000 000   |
| units         | 100         | 100         |
| units/second  | 100 000 000 | 100 000 000 |
| time per unit | 0.0100 μs   | 0.0100 μs   |

### PrimitiveEquatable
| stat          | Before     | After      |
| ------------- | ---------- | ---------- |
| total runs    | 520 591    | 519 660    |
| total time    | 2.0000  s  | 2.0000  s  |
| average run   | 3 μs       | 3 μs       |
| runs/second   | 333 333    | 333 333    |
| units         | 100        | 100        |
| units/second  | 33 333 333 | 33 333 333 |
| time per unit | 0.0300 μs  | 0.0300 μs  |

### CollectionEquatable (static, small)
| stat          | Before    | After     |
| ------------- | --------- | --------- |
| total runs    | 89 451    | 75 242    |
| total time    | 2.0000  s | 2.0000  s |
| average run   | 22 μs     | 26 μs     |
| runs/second   | 45 455    | 38 462    |
| units         | 100       | 100       |
| units/second  | 4 545 455 | 3 846 154 |
| time per unit | 0.2200 μs | 0.2600 μs |

### CollectionEquatable (static, medium)
| stat          | Before    | After     |
| ------------- | --------- | --------- |
| total runs    | 59 444    | 67 114    |
| total time    | 2.0000  s | 2.0000  s |
| average run   | 33 μs     | 29 μs     |
| runs/second   | 30 303    | 34 483    |
| units         | 100       | 100       |
| units/second  | 3 030 303 | 3 448 276 |
| time per unit | 0.3300 μs | 0.2900 μs |

### CollectionEquatable (static, large)
| stat          | Before    | After     |
| ------------- | --------- | --------- |
| total runs    | 15 980    | 32 739    |
| total time    | 2.0001  s | 2.0000  s |
| average run   | 125 μs    | 61 μs     |
| runs/second   | 8 000.0   | 16 393    |
| units         | 100       | 100       |
| units/second  | 800 000   | 1 639 344 |
| time per unit | 1.2500 μs | 0.6100 μs |

### CollectionEquatable (dynamic, small)
| stat          | Before     | After      |
| ------------- | ---------- | ---------- |
| total runs    | 251 623    | 223 689    |
| total time    | 2.0000  s  | 2.0000  s  |
| average run   | 7 μs       | 8 μs       |
| runs/second   | 142 857    | 125 000    |
| units         | 100        | 100        |
| units/second  | 14 285 714 | 12 500 000 |
| time per unit | 0.0700 μs  | 0.0800 μs  |

### CollectionEquatable (dynamic, medium)
| stat          | Before     | After      |
| ------------- | ---------- | ---------- |
| total runs    | 251 419    | 217 705    |
| total time    | 2.0000  s  | 2.0000  s  |
| average run   | 7 μs       | 9 μs       |
| runs/second   | 142 857    | 111 111    |
| units         | 100        | 100        |
| units/second  | 14 285 714 | 11 111 111 |
| time per unit | 0.0700 μs  | 0.0900 μs  |

### CollectionEquatable (dynamic, large)
| stat          | Before     | After      |
| ------------- | ---------- | ---------- |
| total runs    | 249 609    | 215 003    |
| total time    | 2.0000  s  | 2.0000  s  |
| average run   | 8 μs       | 9 μs       |
| runs/second   | 125 000    | 111 111    |
| units         | 100        | 100        |
| units/second  | 12 500 000 | 11 111 111 |
| time per unit | 0.0800 μs  | 0.0900 μs  |
</details>