### PR TITLE
feat: introduce equatable_lint package

### DIFF
--- a/packages/equatable_lint/CHANGELOG.md
+++ b/packages/equatable_lint/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial experimental release of equatable_lint package.

--- a/packages/equatable_lint/LICENSE
+++ b/packages/equatable_lint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Felix Angelov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/equatable_lint/README.md
+++ b/packages/equatable_lint/README.md
@@ -1,0 +1,40 @@
+# Equatable Lint
+
+Official lint rules for development when using the Equatable package.
+
+This package is built to work with:
+
+- [equatable](https://pub.dev/packages/equatable)
+
+---
+
+## Quick Start
+
+1. Install the [equatable_lint](https://pub.dev/packages/equatable_lint) package
+
+   ```sh
+   dart pub add --dev equatable_lint
+   ```
+
+2. Add an `analysis_options.yaml` to the root of your project with the
+   recommended rules
+
+   ```yaml
+   analyzer:
+      plugins:
+         - equatable_lint
+   ```
+
+3. Run the linter
+
+   ```sh
+   dart analyze
+   ```
+
+## Dart Versions
+
+- Dart 3: >= 3.10.0
+
+## Maintainers
+
+- [Felix Angelov](https://github.com/felangel)

--- a/packages/equatable_lint/analysis_options.yaml
+++ b/packages/equatable_lint/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../analysis_options.yaml

--- a/packages/equatable_lint/lib/main.dart
+++ b/packages/equatable_lint/lib/main.dart
@@ -1,0 +1,4 @@
+import 'package:equatable_lint/src/plugin.dart';
+
+/// Top-level plugin instance for Equatable Lint.
+final plugin = EquatableLintPlugin();

--- a/packages/equatable_lint/lib/src/plugin.dart
+++ b/packages/equatable_lint/lib/src/plugin.dart
@@ -1,0 +1,14 @@
+import 'package:analysis_server_plugin/plugin.dart';
+import 'package:analysis_server_plugin/registry.dart';
+import 'package:equatable_lint/src/rules/rules.dart';
+
+/// Equatable Lint Plugin
+class EquatableLintPlugin extends Plugin {
+  @override
+  void register(PluginRegistry registry) {
+    registry.registerWarningRule(DoIncludeAllFieldsInPropsRule());
+  }
+
+  @override
+  String get name => 'equatable_lint';
+}

--- a/packages/equatable_lint/lib/src/rules/do_include_all_fields_in_props.dart
+++ b/packages/equatable_lint/lib/src/rules/do_include_all_fields_in_props.dart
@@ -1,0 +1,132 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
+
+/// @{template do_include_all_fields_in_props}
+/// Ensures all non-static fields in an Equatable class are listed in
+/// the `props` getter for correct equality comparison.
+/// @{endtemplate}
+class DoIncludeAllFieldsInPropsRule extends AnalysisRule {
+  /// @{macro do_include_all_fields_in_props}
+  DoIncludeAllFieldsInPropsRule()
+    : super(
+        name: 'do_include_all_fields_in_props',
+        description:
+            'Ensure all fields are included in props when using Equatable.',
+      );
+
+  static const LintCode _code = LintCode(
+    'do_include_all_fields_in_props',
+    'Missing fields in Equatable props.',
+    correctionMessage: "Add the missing fields to the 'props' getter: {0}.",
+  );
+
+  /// The name of the lint rule.
+  static const String rule = 'do_include_all_fields_in_props';
+
+  @override
+  LintCode get diagnosticCode => _code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final visitor = _Visitor(this, context);
+    registry.addClassDeclaration(this, visitor);
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  _Visitor(this.rule, this.context);
+
+  final AnalysisRule rule;
+  final RuleContext context;
+
+  static const String _equatableClassName = 'Equatable';
+  static const String _equatableMixinName = 'EquatableMixin';
+  static const String _propsGetterName = 'props';
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    if (!_isEquatable(node)) return;
+
+    final declaredFields = _extractDeclaredFieldNames(node);
+    if (declaredFields.isEmpty) return;
+
+    final propsMethod = _findPropsGetter(node);
+    if (propsMethod == null) return;
+
+    final usedProps = _extractPropsNames(propsMethod.body);
+    if (usedProps == null) return;
+
+    final missingFields = declaredFields.difference(usedProps);
+
+    if (missingFields.isNotEmpty) {
+      rule.reportAtToken(
+        propsMethod.name,
+        arguments: [missingFields.join(', ')],
+      );
+    }
+  }
+
+  bool _isEquatable(ClassDeclaration node) {
+    if (node.extendsClause?.superclass.name.lexeme == _equatableClassName) {
+      return true;
+    }
+
+    if (node.withClause != null) {
+      for (final type in node.withClause!.mixinTypes) {
+        if (type.name.lexeme == _equatableMixinName) return true;
+      }
+    }
+
+    return false;
+  }
+
+  Set<String> _extractDeclaredFieldNames(ClassDeclaration node) {
+    final fieldNames = <String>{};
+
+    for (final member in node.members) {
+      if (member is FieldDeclaration && !member.isStatic) {
+        for (final variable in member.fields.variables) {
+          fieldNames.add(variable.name.lexeme);
+        }
+      }
+    }
+
+    return fieldNames;
+  }
+
+  Set<String>? _extractPropsNames(FunctionBody body) {
+    if (body is! ExpressionFunctionBody) return null;
+
+    final expression = body.expression;
+    if (expression is! ListLiteral) return null;
+
+    final propNames = <String>{};
+
+    for (final element in expression.elements) {
+      if (element is SimpleIdentifier) {
+        propNames.add(element.name);
+      }
+    }
+
+    return propNames;
+  }
+
+  MethodDeclaration? _findPropsGetter(ClassDeclaration node) {
+    for (final member in node.members) {
+      if (member is MethodDeclaration &&
+          member.isGetter &&
+          member.name.lexeme == _propsGetterName) {
+        return member;
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/equatable_lint/lib/src/rules/rules.dart
+++ b/packages/equatable_lint/lib/src/rules/rules.dart
@@ -1,0 +1,1 @@
+export 'do_include_all_fields_in_props.dart';

--- a/packages/equatable_lint/pubspec.yaml
+++ b/packages/equatable_lint/pubspec.yaml
@@ -1,0 +1,21 @@
+name: equatable_lint
+description: Official lint rules for development when using the Equatable package.
+version: 0.0.1
+repository: https://github.com/felangel/equatable/tree/master/packages/equatable_lint
+issue_tracker: https://github.com/felangel/equatable/issues
+homepage: https://github.com/felangel/equatable
+documentation: https://github.com/felangel/equatable
+topics: [equality, equals, lint]
+funding: [https://github.com/sponsors/felangel]
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  analysis_server_plugin: ^0.3.0
+  analyzer: ^8.4.0
+
+dev_dependencies:
+  analyzer_testing: ^0.1.5
+  test: ^1.0.0
+  test_reflective_loader: ^0.4.0

--- a/packages/equatable_lint/test/src/rules/do_include_all_fields_in_props_test.dart
+++ b/packages/equatable_lint/test/src/rules/do_include_all_fields_in_props_test.dart
@@ -1,0 +1,144 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:analyzer/src/lint/registry.dart';
+import 'package:analyzer/utilities/package_config_file_builder.dart';
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:equatable_lint/src/rules/do_include_all_fields_in_props.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(DoIncludeAllFieldsInPropsRuleTest);
+  });
+}
+
+@reflectiveTest
+class DoIncludeAllFieldsInPropsRuleTest extends AnalysisRuleTest {
+  @override
+  String get analysisRule => DoIncludeAllFieldsInPropsRule.rule;
+
+  @override
+  void setUp() {
+    Registry.ruleRegistry.registerLintRule(DoIncludeAllFieldsInPropsRule());
+
+    // Create a minimal equatable package
+    newFile('$packagesRootPath/equatable/lib/equatable.dart', '''
+abstract class Equatable {
+  const Equatable();
+
+  List<Object?> get props;
+}
+mixin EquatableMixin {
+  List<Object?> get props;
+}
+''');
+
+    super.setUp();
+  }
+
+  @override
+  void writeTestPackageConfig(PackageConfigFileBuilder config) {
+    config.add(name: 'equatable', rootPath: '$packagesRootPath/equatable');
+    super.writeTestPackageConfig(config);
+  }
+
+  Future<void> test_equatableExtendsValid_noLint() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Person extends Equatable {
+  final String name;
+  final int age;
+
+  const Person(this.name, this.age);
+
+  @override
+  List<Object> get props => [name, age];
+}
+''');
+  }
+
+  Future<void> test_equatableExtendsMissingField_reportsLint() async {
+    await assertDiagnostics(
+      '''
+import 'package:equatable/equatable.dart';
+
+class Person extends Equatable {
+  final String name;
+  final int age;
+
+  const Person(this.name, this.age);
+
+  @override
+  List<Object> get props => [name];
+}
+''',
+      [lint(185, 5, messageContains: 'Missing fields in Equatable props')],
+    );
+  }
+
+  Future<void> test_equatableMixinValid_noLint() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Person with EquatableMixin {
+  final String name;
+  final int age;
+
+  const Person(this.name, this.age);
+
+  @override
+  List<Object> get props => [name, age];
+}
+''');
+  }
+
+  Future<void> test_equatableMixinMissingField_reportsLint() async {
+    await assertDiagnostics(
+      '''
+import 'package:equatable/equatable.dart';
+
+class Person with EquatableMixin {
+  final String name;
+  final int age;
+
+  const Person(this.name, this.age);
+
+  @override
+  List<Object> get props => [name];
+}
+''',
+      [lint(187, 5, correctionContains: 'age')],
+    );
+  }
+
+  Future<void> test_ignoresStaticFields_noLint() async {
+    await assertNoDiagnostics('''
+import 'package:equatable/equatable.dart';
+
+class Person extends Equatable {
+  final String name;
+
+  static const String species = 'Homo sapiens';
+
+  const Person(this.name);
+
+  @override
+  List<Object> get props => [name];
+}
+''');
+  }
+
+  Future<void> test_notEquatable_noLint() async {
+    await assertNoDiagnostics('''
+class Person {
+  final String name;
+  final int age;
+
+  const Person(this.name, this.age);
+
+  List<Object> get props => [name];
+}
+''');
+  }
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description

Introduce `equatable_lint` package using the new [Analyzer system](https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server_plugin/doc/writing_a_plugin.md). It also includes a very first `do_include_all_fields_in_props` lint rule.

## Related Issue

- Part of #201

## Impact to Remaining Code Base

We might want to move the current equatable code to `packages/equatable`

## Visual Reference

<img width="981" height="361" alt="Screenshot 2025-11-17 at 23 39 53" src="https://github.com/user-attachments/assets/4b88abef-6ec6-4399-b54a-81f96cd558b3" />

