### PR TITLE
fix!: avoid custom `toString` override

### DIFF
--- a/lib/src/equatable.dart
+++ b/lib/src/equatable.dart
@@ -57,6 +57,6 @@ abstract class Equatable {
     if (stringify ?? EquatableConfig.stringify) {
       return mapPropsToString(runtimeType, props);
     }
-    return '$runtimeType';
+    return super.toString();
   }
 }

--- a/lib/src/equatable_mixin.dart
+++ b/lib/src/equatable_mixin.dart
@@ -33,6 +33,6 @@ mixin EquatableMixin {
     if (stringify ?? EquatableConfig.stringify) {
       return mapPropsToString(runtimeType, props);
     }
-    return '$runtimeType';
+    return super.toString();
   }
 }

--- a/test/equatable_config_test.dart
+++ b/test/equatable_config_test.dart
@@ -62,11 +62,11 @@ void main() {
         EquatableConfig.stringify = false;
         expect(
           Credentials(username: 'joe', password: 'pass').toString(),
-          'Credentials',
+          "Instance of 'Credentials'",
         );
         expect(
           CredentialsMixin(username: 'joe', password: 'pass').toString(),
-          'CredentialsMixin',
+          "Instance of 'CredentialsMixin'",
         );
       });
 
@@ -113,7 +113,7 @@ void main() {
             password: 'pass',
             shouldStringify: false,
           ).toString(),
-          'Credentials',
+          "Instance of 'Credentials'",
         );
         expect(
           CredentialsMixin(
@@ -121,7 +121,7 @@ void main() {
             password: 'pass',
             shouldStringify: false,
           ).toString(),
-          'CredentialsMixin',
+          "Instance of 'CredentialsMixin'",
         );
       });
     });

--- a/test/equatable_mixin_test.dart
+++ b/test/equatable_mixin_test.dart
@@ -175,7 +175,7 @@ void main() {
     test('should correct toString when EquatableConfig.stringify is false', () {
       EquatableConfig.stringify = false;
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<String>'");
     });
 
     test('should return true when instance is the same', () {
@@ -660,9 +660,12 @@ void main() {
           ExplicitStringifyFalse(name: 'Bob', hairColor: Color.black);
       final instanceC =
           ExplicitStringifyFalse(name: 'Joe', age: 50, hairColor: Color.blonde);
-      expect(instanceA.toString(), 'ExplicitStringifyFalse');
-      expect(instanceB.toString(), 'ExplicitStringifyFalse');
-      expect(instanceC.toString(), 'ExplicitStringifyFalse');
+
+      const expected = "Instance of 'ExplicitStringifyFalse'";
+
+      expect(instanceA.toString(), expected);
+      expect(instanceB.toString(), expected);
+      expect(instanceC.toString(), expected);
     });
   });
 

--- a/test/equatable_test.dart
+++ b/test/equatable_test.dart
@@ -192,7 +192,7 @@ void main() {
     test('should correct toString when EquatableConfig.stringify is false', () {
       EquatableConfig.stringify = false;
       final instance = SimpleEquatable('simple');
-      expect(instance.toString(), 'SimpleEquatable<String>');
+      expect(instance.toString(), "Instance of 'SimpleEquatable<String>'");
     });
 
     test('should return true when instance is the same', () {
@@ -1057,9 +1057,12 @@ void main() {
         age: 50,
         hairColor: Color.blonde,
       );
-      expect(instanceA.toString(), 'ExplicitStringifyFalse');
-      expect(instanceB.toString(), 'ExplicitStringifyFalse');
-      expect(instanceC.toString(), 'ExplicitStringifyFalse');
+
+      const expected = "Instance of 'ExplicitStringifyFalse'";
+
+      expect(instanceA.toString(), expected);
+      expect(instanceB.toString(), expected);
+      expect(instanceC.toString(), expected);
     });
   });
 }


### PR DESCRIPTION
# Issue #212


## Status
**READY**

## Breaking Changes
**YES**

## Description
Change the default toString() implementation in equatable.dart and equatable_mixin.dart.
This changes changes `return '$runtimeType';` -> `return super.toString();`

## Todos
- [x] Tests
- [ ] Documentation
- [x] Examples

## Impact on Existing Codebases

This is a **behavioral breaking change** for any class that:

1. Mixes in `EquatableMixin`, **and**
2. Does **not** override `toString()` itself, **and**
3. Inherits a non-default `toString()` from a superclass.

Additionally, any class extending `Equatable` or mixing in `EquatableMixin` that relies on the current `'$runtimeType'` string format will observe a change to `Instance of 'ClassName'`. Teams are advised to audit usages of `.toString()` (including implicit calls via string interpolation or `print`) on classes that extend or mix in equatable abstractions.